### PR TITLE
Stage 2: Full subpage build with real content

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -2,10 +2,10 @@
   "version": "0.0.1",
   "configurations": [
     {
-      "name": "dev",
+      "name": "180life-dev",
       "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "dev"],
-      "port": 3000
+      "runtimeArgs": ["run", "dev", "--", "--port", "3004"],
+      "port": 3004
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.2.0",
+        "pdfkit": "^0.18.0",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -1190,6 +1191,32 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -4821,6 +4848,13 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5775,6 +5809,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pdfkit": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.18.0.tgz",
+      "integrity": "sha512-NvUwSDZ0eYEzqAiWwVQkRkjYUkZ48kcsHuCO31ykqPPIVkwoSDjDGiwIgHHNtsiwls3z3P/zy4q00hl2chg2Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
+        "fontkit": "^2.0.4",
+        "js-md5": "^0.8.3",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.0.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5793,6 +5842,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/png-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
+      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g==",
+      "dev": true
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.2.0",
+    "pdfkit": "^0.18.0",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,175 @@
+import { Navbar } from "@/components/Navbar";
+import { Footer } from "@/components/Footer";
+import { PageHero } from "@/components/PageHero";
+import { ContentSection } from "@/components/ContentSection";
+import { FadeIn } from "@/components/FadeIn";
+import { getFooterProps } from "@/lib/wordpress-fallbacks";
+import { CONTENT_PAGES } from "@/lib/subpage-fallbacks";
+import { Users, Heart, BookOpen, HandHeart, ArrowRight } from "lucide-react";
+import type { Metadata } from "next";
+
+const data = CONTENT_PAGES["about"];
+
+export const metadata: Metadata = {
+  title: "About Us | 180 Life Church",
+  description: data.subtitle,
+};
+
+const nextSteps = [
+  {
+    icon: Users,
+    title: "Meet Our Team",
+    description:
+      "Get to know the pastors, staff, and elders who shepherd our church family.",
+    href: "/leadership",
+    color: "from-teal/80 to-charcoal/90",
+  },
+  {
+    icon: Heart,
+    title: "Partnership",
+    description:
+      "Learn how to become a partner and discover your place in the church body.",
+    href: "/partnership",
+    color: "from-amber/70 to-charcoal/90",
+  },
+  {
+    icon: BookOpen,
+    title: "Baptism & Dedication",
+    description:
+      "Ready to take your next step of faith? Learn about baptism and child dedication.",
+    href: "/baptism",
+    color: "from-indigo-500/70 to-charcoal/90",
+  },
+  {
+    icon: HandHeart,
+    title: "Stories",
+    description:
+      "See how God is transforming lives at 180 Life Church.",
+    href: "/stories",
+    color: "from-rose-500/70 to-charcoal/90",
+  },
+];
+
+export default function AboutPage() {
+  const footerProps = getFooterProps();
+
+  return (
+    <>
+      <Navbar />
+      <PageHero
+        title={data.title}
+        subtitle={data.subtitle}
+        breadcrumbs={data.breadcrumbs}
+      />
+
+      {data.sections.map((section, i) => (
+        <ContentSection
+          key={i}
+          label={section.label}
+          heading={section.heading}
+          headingAccent={section.headingAccent}
+          body={section.body}
+          image={section.image}
+          background={i % 2 === 0 ? "soft-white" : "white"}
+        />
+      ))}
+
+      {/* Next Steps */}
+      <section className="bg-soft-white py-16 sm:py-20">
+        <div className="max-w-5xl mx-auto px-6">
+          <FadeIn>
+            <div className="text-center mb-12">
+              <span className="text-amber text-sm font-medium tracking-[0.2em] uppercase">
+                Go Deeper
+              </span>
+              <h2
+                className="text-3xl sm:text-4xl font-bold text-charcoal mt-3"
+                style={{ fontFamily: "var(--font-playfair)" }}
+              >
+                Next <span className="text-amber">Steps</span>
+              </h2>
+            </div>
+          </FadeIn>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
+            {nextSteps.map((step, i) => {
+              const Icon = step.icon;
+              return (
+                <FadeIn key={step.title} delay={i * 0.05}>
+                  <a
+                    href={step.href}
+                    className={`group relative block rounded-2xl overflow-hidden cursor-pointer h-full min-h-[240px] flex flex-col hover:-translate-y-1.5 transition-all duration-500 hover:shadow-2xl hover:shadow-black/20`}
+                  >
+                    {/* Gradient background */}
+                    <div className={`absolute inset-0 bg-gradient-to-br ${step.color}`} />
+
+                    {/* Watermark */}
+                    <div className="absolute top-3 right-3 opacity-[0.08] group-hover:opacity-[0.15] transition-opacity duration-500">
+                      <Icon size={100} className="text-white" strokeWidth={1} />
+                    </div>
+
+                    {/* Content */}
+                    <div className="relative p-6 flex flex-col flex-1 z-10">
+                      <span className="flex items-center justify-center w-10 h-10 rounded-full bg-white/10 backdrop-blur-md border border-white/10 mb-auto">
+                        <Icon className="text-white" size={18} />
+                      </span>
+
+                      <div className="mt-auto">
+                        <h3 className="text-white text-lg font-bold mb-2">
+                          {step.title}
+                        </h3>
+                        <p className="text-white/60 text-sm leading-relaxed mb-3 group-hover:text-white/80 transition-colors duration-300">
+                          {step.description}
+                        </p>
+                        <div className="flex items-center gap-2 pt-3 border-t border-white/10 group-hover:border-white/20 transition-colors">
+                          <span className="text-white/70 text-sm font-medium group-hover:text-amber transition-colors duration-300">
+                            Explore
+                          </span>
+                          <ArrowRight size={14} className="text-white/40 group-hover:text-amber group-hover:translate-x-1.5 transition-all duration-300" />
+                        </div>
+                      </div>
+                    </div>
+                  </a>
+                </FadeIn>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      {data.cta && (
+        <section
+          className="py-16 sm:py-20 text-center"
+          style={{
+            background:
+              "radial-gradient(ellipse at 50% 50%, rgba(212, 160, 84, 0.15) 0%, transparent 60%), linear-gradient(to bottom, #1A1A1A, #201C16, #1A1A1A)",
+          }}
+        >
+          <div className="max-w-3xl mx-auto px-6">
+            <FadeIn>
+              <h2
+                className="text-3xl sm:text-4xl font-bold text-white mb-6"
+                style={{ fontFamily: "var(--font-playfair)" }}
+              >
+                {data.cta.heading}
+              </h2>
+              {data.cta.description && (
+                <p className="text-white/60 text-lg mb-8 max-w-xl mx-auto">
+                  {data.cta.description}
+                </p>
+              )}
+              <a
+                href={data.cta.link}
+                className="inline-flex items-center gap-2 px-8 py-3.5 bg-amber text-charcoal font-semibold rounded-full hover:bg-amber-light transition-all hover:shadow-lg hover:shadow-amber/25"
+              >
+                {data.cta.text}
+              </a>
+            </FadeIn>
+          </div>
+        </section>
+      )}
+
+      <Footer {...footerProps} />
+    </>
+  );
+}

--- a/src/app/baptism/page.tsx
+++ b/src/app/baptism/page.tsx
@@ -1,0 +1,14 @@
+import { ContentPageTemplate } from "@/components/templates/ContentPageTemplate";
+import { CONTENT_PAGES } from "@/lib/subpage-fallbacks";
+import type { Metadata } from "next";
+
+const data = CONTENT_PAGES["baptism"];
+
+export const metadata: Metadata = {
+  title: "Baptism | 180 Life Church",
+  description: data.subtitle,
+};
+
+export default function BaptismPage() {
+  return <ContentPageTemplate data={data} />;
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,134 @@
+import { Navbar } from "@/components/Navbar";
+import { Footer } from "@/components/Footer";
+import { PageHero } from "@/components/PageHero";
+import { ContactForm } from "@/components/ContactForm";
+import { FadeIn } from "@/components/FadeIn";
+import { getFooterProps, FALLBACK_SETTINGS } from "@/lib/wordpress-fallbacks";
+import { MapPin, Phone, Mail, Clock } from "lucide-react";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Contact Us | 180 Life Church",
+  description:
+    "Get in touch with 180 Life Church in Bloomfield, CT. Send us a message, submit a prayer request, or plan your visit.",
+};
+
+export default function ContactPage() {
+  const footerProps = getFooterProps();
+  const { contact } = FALLBACK_SETTINGS;
+
+  return (
+    <>
+      <Navbar />
+      <PageHero
+        title="Contact Us"
+        subtitle="We'd love to hear from you. Reach out with questions, prayer requests, or just to say hello."
+        breadcrumbs={[{ label: "Contact", href: "/contact" }]}
+      />
+
+      <section className="bg-soft-white py-16 sm:py-20">
+        <div className="max-w-6xl mx-auto px-6">
+          <div className="grid lg:grid-cols-5 gap-10">
+            {/* Contact Form */}
+            <div className="lg:col-span-3">
+              <FadeIn>
+                <ContactForm
+                  heading="Send Us a Message"
+                  description="Fill out the form below and we'll get back to you as soon as possible."
+                />
+              </FadeIn>
+            </div>
+
+            {/* Contact Info Sidebar */}
+            <div className="lg:col-span-2 space-y-6">
+              <FadeIn delay={0.1}>
+                <div className="bg-white rounded-2xl border border-charcoal/8 p-6">
+                  <h3
+                    className="text-xl font-bold text-charcoal mb-5"
+                    style={{ fontFamily: "var(--font-playfair)" }}
+                  >
+                    Visit Us
+                  </h3>
+                  <ul className="space-y-4">
+                    <li className="flex items-start gap-3">
+                      <div className="w-9 h-9 rounded-lg bg-amber/10 flex items-center justify-center shrink-0 mt-0.5">
+                        <MapPin className="text-amber" size={16} />
+                      </div>
+                      <div>
+                        <p className="font-medium text-charcoal text-sm">Address</p>
+                        <p className="text-charcoal/60 text-sm">
+                          {contact.addressLine1}
+                          <br />
+                          {contact.addressLine2}
+                        </p>
+                      </div>
+                    </li>
+                    <li className="flex items-start gap-3">
+                      <div className="w-9 h-9 rounded-lg bg-amber/10 flex items-center justify-center shrink-0 mt-0.5">
+                        <Clock className="text-amber" size={16} />
+                      </div>
+                      <div>
+                        <p className="font-medium text-charcoal text-sm">Service Times</p>
+                        <p className="text-charcoal/60 text-sm">
+                          {contact.serviceTimesSummary}
+                          <br />
+                          {contact.doorsOpenText}
+                        </p>
+                      </div>
+                    </li>
+                    <li className="flex items-start gap-3">
+                      <div className="w-9 h-9 rounded-lg bg-amber/10 flex items-center justify-center shrink-0 mt-0.5">
+                        <Phone className="text-amber" size={16} />
+                      </div>
+                      <div>
+                        <p className="font-medium text-charcoal text-sm">Phone</p>
+                        <a
+                          href={`tel:${contact.phone.replace(/[^\d+]/g, "")}`}
+                          className="text-charcoal/60 text-sm hover:text-amber transition-colors"
+                        >
+                          {contact.phone}
+                        </a>
+                      </div>
+                    </li>
+                    <li className="flex items-start gap-3">
+                      <div className="w-9 h-9 rounded-lg bg-amber/10 flex items-center justify-center shrink-0 mt-0.5">
+                        <Mail className="text-amber" size={16} />
+                      </div>
+                      <div>
+                        <p className="font-medium text-charcoal text-sm">Email</p>
+                        <a
+                          href={`mailto:${contact.email}`}
+                          className="text-charcoal/60 text-sm hover:text-amber transition-colors"
+                        >
+                          {contact.email}
+                        </a>
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+              </FadeIn>
+
+              {/* Map placeholder */}
+              <FadeIn delay={0.2}>
+                <div className="bg-white rounded-2xl border border-charcoal/8 overflow-hidden">
+                  <iframe
+                    title="180 Life Church Location"
+                    src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2980.5!2d-72.74!3d41.83!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x0!2s180+Still+Road+Bloomfield+CT!5e0!3m2!1sen!2sus!4v1"
+                    width="100%"
+                    height="250"
+                    style={{ border: 0 }}
+                    allowFullScreen
+                    loading="lazy"
+                    referrerPolicy="no-referrer-when-downgrade"
+                  />
+                </div>
+              </FadeIn>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <Footer hideChecklistBanner {...footerProps} />
+    </>
+  );
+}

--- a/src/app/give/page.tsx
+++ b/src/app/give/page.tsx
@@ -1,0 +1,241 @@
+import { Navbar } from "@/components/Navbar";
+import { Footer } from "@/components/Footer";
+import { PageHero } from "@/components/PageHero";
+import { FadeIn } from "@/components/FadeIn";
+import { getFooterProps } from "@/lib/wordpress-fallbacks";
+import {
+  Heart,
+  Shield,
+  DollarSign,
+  Gift,
+  Smartphone,
+  BookOpen,
+  HandCoins,
+  CreditCard,
+} from "lucide-react";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Give | 180 Life Church",
+  description:
+    "Support the mission of 180 Life Church through your generous giving. Give online, by text, in person, or by mail.",
+};
+
+export default function GivePage() {
+  const footerProps = getFooterProps();
+
+  return (
+    <>
+      <Navbar />
+      <PageHero
+        title="Give"
+        subtitle="Your generosity fuels our mission to make and send disciples who love and live like Jesus."
+        breadcrumbs={[{ label: "Give", href: "/give" }]}
+      />
+
+      {/* Why We Tithe */}
+      <section className="bg-soft-white py-16 sm:py-20">
+        <div className="max-w-3xl mx-auto px-6">
+          <FadeIn>
+            <div className="text-center mb-10">
+              <span className="text-amber text-sm font-medium tracking-[0.2em] uppercase">
+                Generosity
+              </span>
+              <h2
+                className="text-3xl sm:text-4xl font-bold text-charcoal mt-3"
+                style={{ fontFamily: "var(--font-playfair)" }}
+              >
+                Why We <span className="text-amber">Tithe</span>
+              </h2>
+            </div>
+            <div className="space-y-4 text-charcoal/60 leading-relaxed">
+              <p>
+                A tithe literally means a &quot;tenth&quot; and refers to giving
+                10% of your income to God through the local church. When we
+                tithe, we are acknowledging that everything we have belongs to
+                God and trusting Him to provide.
+              </p>
+              <p>
+                &quot;Bring the whole tithe into the storehouse, that there may
+                be food in my house. Test me in this,&quot; says the Lord
+                Almighty, &quot;and see if I will not throw open the floodgates
+                of heaven and pour out so much blessing that there will not be
+                room enough to store it.&quot; (Malachi 3:10)
+              </p>
+              <p>
+                Your generous giving supports our ministries, serves our
+                community, covers operational costs, and advances the Gospel
+                locally and around the world.
+              </p>
+            </div>
+          </FadeIn>
+        </div>
+      </section>
+
+      {/* Give Online CTA */}
+      <section className="bg-white py-16 sm:py-20">
+        <div className="max-w-3xl mx-auto px-6 text-center">
+          <FadeIn>
+            <div className="w-16 h-16 rounded-2xl bg-amber/10 flex items-center justify-center mx-auto mb-6">
+              <Heart className="text-amber" size={28} />
+            </div>
+            <h2
+              className="text-3xl font-bold text-charcoal mb-4"
+              style={{ fontFamily: "var(--font-playfair)" }}
+            >
+              Give <span className="text-amber">Online</span>
+            </h2>
+            <p className="text-charcoal/60 text-lg max-w-xl mx-auto mb-8 leading-relaxed">
+              Give securely online through our giving platform. You can make a
+              one-time gift or set up recurring giving.
+            </p>
+            <a
+              href="https://180lifechurch.churchcenter.com/giving"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-3 px-10 py-4 bg-amber text-charcoal font-bold rounded-full hover:bg-amber-light transition-all hover:shadow-2xl hover:shadow-amber/30 text-lg hover:scale-105"
+            >
+              Give Now
+              <Gift size={20} />
+            </a>
+          </FadeIn>
+        </div>
+      </section>
+
+      {/* Ways to Give */}
+      <section className="bg-soft-white py-16 sm:py-20">
+        <div className="max-w-5xl mx-auto px-6">
+          <FadeIn>
+            <h2
+              className="text-3xl font-bold text-charcoal mb-10 text-center"
+              style={{ fontFamily: "var(--font-playfair)" }}
+            >
+              Ways to <span className="text-amber">Give</span>
+            </h2>
+          </FadeIn>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
+            {[
+              {
+                Icon: CreditCard,
+                title: "Online",
+                desc: "Give securely through Church Center. Set up one-time or recurring gifts with a debit card, credit card, or bank transfer.",
+                color: "from-teal/80 to-charcoal/90",
+              },
+              {
+                Icon: Smartphone,
+                title: "Text to Give",
+                desc: "Text any dollar amount to 84321 to give quickly from your phone. First-time givers will receive a registration link.",
+                color: "from-amber/70 to-charcoal/90",
+              },
+              {
+                Icon: HandCoins,
+                title: "In Person",
+                desc: "Drop your gift in an offering envelope during any Sunday service. Envelopes are available at the back of the auditorium.",
+                color: "from-indigo-500/70 to-charcoal/90",
+              },
+              {
+                Icon: DollarSign,
+                title: "Non-Cash Giving",
+                desc: "We accept non-cash gifts such as stock, real estate, and other assets. Contact us for more information.",
+                color: "from-emerald-600/70 to-charcoal/90",
+              },
+            ].map((card, i) => (
+              <FadeIn key={card.title} delay={i * 0.05}>
+                <div className="group relative rounded-2xl overflow-hidden h-full min-h-[240px] flex flex-col hover:-translate-y-1.5 transition-all duration-500 hover:shadow-2xl hover:shadow-black/20">
+                  {/* Gradient background */}
+                  <div className={`absolute inset-0 bg-gradient-to-br ${card.color}`} />
+
+                  {/* Watermark */}
+                  <div className="absolute top-3 right-3 opacity-[0.08] group-hover:opacity-[0.15] transition-opacity duration-500">
+                    <card.Icon size={100} className="text-white" strokeWidth={1} />
+                  </div>
+
+                  {/* Content */}
+                  <div className="relative p-6 flex flex-col flex-1 z-10 text-center">
+                    <span className="flex items-center justify-center w-12 h-12 rounded-full bg-white/10 backdrop-blur-md border border-white/10 mx-auto mb-4">
+                      <card.Icon className="text-white" size={20} />
+                    </span>
+                    <h3 className="text-white text-lg font-bold mb-2">{card.title}</h3>
+                    <p className="text-white/60 text-sm leading-relaxed group-hover:text-white/80 transition-colors duration-300">
+                      {card.desc}
+                    </p>
+                  </div>
+                </div>
+              </FadeIn>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Financial Peace University */}
+      <section className="bg-white py-16 sm:py-20">
+        <div className="max-w-3xl mx-auto px-6">
+          <FadeIn>
+            <div className="bg-soft-white rounded-2xl border border-charcoal/8 p-8">
+              <div className="flex items-start gap-4">
+                <div className="w-10 h-10 rounded-lg bg-amber/10 flex items-center justify-center shrink-0 mt-0.5">
+                  <BookOpen className="text-amber" size={20} />
+                </div>
+                <div>
+                  <h3 className="font-bold text-charcoal text-lg mb-2">
+                    Financial Peace University
+                  </h3>
+                  <p className="text-charcoal/60 leading-relaxed mb-3">
+                    Want to take control of your finances? Financial Peace
+                    University (FPU) is a proven plan that teaches you how to
+                    make the right decisions with your money. Through video
+                    lessons and group discussions, you will learn how to budget,
+                    pay off debt, save for emergencies, and invest for your
+                    future.
+                  </p>
+                  <p className="text-charcoal/60 leading-relaxed">
+                    Contact us to find out when the next FPU class begins at 180
+                    Life Church.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </FadeIn>
+        </div>
+      </section>
+
+      {/* Financial Transparency */}
+      <section className="bg-soft-white py-16 sm:py-20">
+        <div className="max-w-3xl mx-auto px-6">
+          <FadeIn>
+            <div className="bg-white rounded-2xl border border-charcoal/8 p-8">
+              <div className="flex items-start gap-4">
+                <div className="w-10 h-10 rounded-lg bg-green-100 flex items-center justify-center shrink-0 mt-0.5">
+                  <Shield className="text-green-600" size={20} />
+                </div>
+                <div>
+                  <h3 className="font-bold text-charcoal text-lg mb-2">
+                    Financial Transparency
+                  </h3>
+                  <p className="text-charcoal/60 leading-relaxed">
+                    We take stewardship seriously. 180 Life Church is committed
+                    to financial integrity and transparency. Our Elders provide
+                    accountability and counsel regarding major financial and
+                    strategic decisions. Your gifts are used to support our
+                    ministries, serve our community, and advance the Gospel. If
+                    you have questions about how funds are used, please reach out
+                    to our Elders at{" "}
+                    <a
+                      href="mailto:elders@180lifechurch.org"
+                      className="text-amber hover:underline"
+                    >
+                      elders@180lifechurch.org
+                    </a>
+                    .
+                  </p>
+                </div>
+              </div>
+            </div>
+          </FadeIn>
+        </div>
+      </section>
+
+      <Footer hideChecklistBanner {...footerProps} />
+    </>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter, Playfair_Display } from "next/font/google";
 import "./globals.css";
+import { BfcacheReloader } from "@/components/BfcacheReloader";
 
 const inter = Inter({
   variable: "--font-inter",
@@ -71,7 +72,10 @@ export default function RootLayout({
       lang="en"
       className={`${inter.variable} ${playfair.variable} antialiased`}
     >
-      <body className="min-h-screen flex flex-col">{children}</body>
+      <body className="min-h-screen flex flex-col">
+        <BfcacheReloader />
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/app/leadership/page.tsx
+++ b/src/app/leadership/page.tsx
@@ -1,0 +1,128 @@
+import { Navbar } from "@/components/Navbar";
+import { Footer } from "@/components/Footer";
+import { PageHero } from "@/components/PageHero";
+import { StaffCard } from "@/components/StaffCard";
+import { FadeIn } from "@/components/FadeIn";
+import { getFooterProps } from "@/lib/wordpress-fallbacks";
+import {
+  LEADERSHIP_DATA,
+  ELDERS,
+  ELDERS_DESCRIPTION,
+  ELDERS_EMAIL,
+} from "@/lib/subpage-fallbacks";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Leadership | 180 Life Church",
+  description:
+    "Meet the pastors and staff who lead 180 Life Church in Bloomfield, CT.",
+};
+
+export default function LeadershipPage() {
+  const footerProps = getFooterProps();
+
+  return (
+    <>
+      <Navbar />
+      <PageHero
+        title="Our Leadership"
+        subtitle="Meet the pastors and team who serve 180 Life Church."
+        breadcrumbs={[{ label: "Leadership", href: "/leadership" }]}
+      />
+
+      {/* Pastors */}
+      <section className="bg-soft-white py-16 sm:py-20">
+        <div className="max-w-5xl mx-auto px-6">
+          <FadeIn>
+            <h2
+              className="text-3xl font-bold text-charcoal mb-10 text-center"
+              style={{ fontFamily: "var(--font-playfair)" }}
+            >
+              Our <span className="text-amber">Pastors</span>
+            </h2>
+          </FadeIn>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-8 justify-center">
+            {LEADERSHIP_DATA.pastors.map((pastor, i) => (
+              <StaffCard
+                key={pastor.name}
+                name={pastor.name}
+                role={pastor.role}
+                image={pastor.image}
+                bio={pastor.bio}
+                delay={i * 0.1}
+              />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Staff */}
+      {LEADERSHIP_DATA.staff.length > 0 && (
+        <section className="bg-white py-16 sm:py-20">
+          <div className="max-w-5xl mx-auto px-6">
+            <FadeIn>
+              <h2
+                className="text-3xl font-bold text-charcoal mb-10 text-center"
+                style={{ fontFamily: "var(--font-playfair)" }}
+              >
+                Our <span className="text-amber">Team</span>
+              </h2>
+            </FadeIn>
+            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-8">
+              {LEADERSHIP_DATA.staff.map((member, i) => (
+                <StaffCard
+                  key={member.name}
+                  name={member.name}
+                  role={member.role}
+                  image={member.image}
+                  bio={member.bio}
+                  delay={i * 0.1}
+                />
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Elders */}
+      <section className="bg-soft-white py-16 sm:py-20">
+        <div className="max-w-4xl mx-auto px-6">
+          <FadeIn>
+            <h2
+              className="text-3xl font-bold text-charcoal mb-4 text-center"
+              style={{ fontFamily: "var(--font-playfair)" }}
+            >
+              Our <span className="text-amber">Elders</span>
+            </h2>
+            <p className="text-charcoal/60 text-center max-w-2xl mx-auto mb-10 leading-relaxed">
+              {ELDERS_DESCRIPTION}
+            </p>
+          </FadeIn>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
+            {ELDERS.map((elder, i) => (
+              <FadeIn key={elder.name} delay={i * 0.05}>
+                <div className="bg-white rounded-2xl border border-charcoal/8 p-6 text-center">
+                  <h3 className="font-bold text-charcoal">{elder.name}</h3>
+                  <p className="text-amber text-sm mt-1">{elder.role}</p>
+                </div>
+              </FadeIn>
+            ))}
+          </div>
+          <FadeIn delay={0.3}>
+            <p className="text-center text-charcoal/50 text-sm mt-8">
+              Contact the Elders:{" "}
+              <a
+                href={`mailto:${ELDERS_EMAIL}`}
+                className="text-amber hover:underline"
+              >
+                {ELDERS_EMAIL}
+              </a>
+            </p>
+          </FadeIn>
+        </div>
+      </section>
+
+      <Footer hideChecklistBanner {...footerProps} />
+    </>
+  );
+}

--- a/src/app/membership/page.tsx
+++ b/src/app/membership/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function MembershipPage() {
+  redirect("/partnership");
+}

--- a/src/app/ministries/care/page.tsx
+++ b/src/app/ministries/care/page.tsx
@@ -1,0 +1,14 @@
+import { MinistryPageTemplate } from "@/components/templates/MinistryPageTemplate";
+import { MINISTRY_PAGES } from "@/lib/subpage-fallbacks";
+import type { Metadata } from "next";
+
+const data = MINISTRY_PAGES["care"];
+
+export const metadata: Metadata = {
+  title: `${data.title} | 180 Life Church`,
+  description: data.subtitle,
+};
+
+export default function CareMinistryPage() {
+  return <MinistryPageTemplate data={data} />;
+}

--- a/src/app/ministries/deaf-ministry/page.tsx
+++ b/src/app/ministries/deaf-ministry/page.tsx
@@ -1,0 +1,14 @@
+import { MinistryPageTemplate } from "@/components/templates/MinistryPageTemplate";
+import { MINISTRY_PAGES } from "@/lib/subpage-fallbacks";
+import type { Metadata } from "next";
+
+const data = MINISTRY_PAGES["deaf-ministry"];
+
+export const metadata: Metadata = {
+  title: `${data.title} | 180 Life Church`,
+  description: data.subtitle,
+};
+
+export default function DeafMinistryPage() {
+  return <MinistryPageTemplate data={data} />;
+}

--- a/src/app/ministries/kids/page.tsx
+++ b/src/app/ministries/kids/page.tsx
@@ -1,0 +1,14 @@
+import { MinistryPageTemplate } from "@/components/templates/MinistryPageTemplate";
+import { MINISTRY_PAGES } from "@/lib/subpage-fallbacks";
+import type { Metadata } from "next";
+
+const data = MINISTRY_PAGES["kids"];
+
+export const metadata: Metadata = {
+  title: `${data.title} | 180 Life Church`,
+  description: data.subtitle,
+};
+
+export default function KidsPage() {
+  return <MinistryPageTemplate data={data} />;
+}

--- a/src/app/ministries/life-groups/page.tsx
+++ b/src/app/ministries/life-groups/page.tsx
@@ -1,0 +1,14 @@
+import { MinistryPageTemplate } from "@/components/templates/MinistryPageTemplate";
+import { MINISTRY_PAGES } from "@/lib/subpage-fallbacks";
+import type { Metadata } from "next";
+
+const data = MINISTRY_PAGES["life-groups"];
+
+export const metadata: Metadata = {
+  title: `${data.title} | 180 Life Church`,
+  description: data.subtitle,
+};
+
+export default function LifeGroupsPage() {
+  return <MinistryPageTemplate data={data} />;
+}

--- a/src/app/ministries/marriage-prep/page.tsx
+++ b/src/app/ministries/marriage-prep/page.tsx
@@ -1,0 +1,14 @@
+import { MinistryPageTemplate } from "@/components/templates/MinistryPageTemplate";
+import { MINISTRY_PAGES } from "@/lib/subpage-fallbacks";
+import type { Metadata } from "next";
+
+const data = MINISTRY_PAGES["marriage-prep"];
+
+export const metadata: Metadata = {
+  title: `${data.title} | 180 Life Church`,
+  description: data.subtitle,
+};
+
+export default function MarriagePrepPage() {
+  return <MinistryPageTemplate data={data} />;
+}

--- a/src/app/ministries/mens/page.tsx
+++ b/src/app/ministries/mens/page.tsx
@@ -1,0 +1,14 @@
+import { MinistryPageTemplate } from "@/components/templates/MinistryPageTemplate";
+import { MINISTRY_PAGES } from "@/lib/subpage-fallbacks";
+import type { Metadata } from "next";
+
+const data = MINISTRY_PAGES["mens"];
+
+export const metadata: Metadata = {
+  title: `${data.title} | 180 Life Church`,
+  description: data.subtitle,
+};
+
+export default function MensMinistryPage() {
+  return <MinistryPageTemplate data={data} />;
+}

--- a/src/app/ministries/missions/page.tsx
+++ b/src/app/ministries/missions/page.tsx
@@ -1,0 +1,14 @@
+import { MinistryPageTemplate } from "@/components/templates/MinistryPageTemplate";
+import { MINISTRY_PAGES } from "@/lib/subpage-fallbacks";
+import type { Metadata } from "next";
+
+const data = MINISTRY_PAGES["missions"];
+
+export const metadata: Metadata = {
+  title: `${data.title} | 180 Life Church`,
+  description: data.subtitle,
+};
+
+export default function MissionsPage() {
+  return <MinistryPageTemplate data={data} />;
+}

--- a/src/app/ministries/page.tsx
+++ b/src/app/ministries/page.tsx
@@ -1,0 +1,343 @@
+import Image from "next/image";
+import { Navbar } from "@/components/Navbar";
+import { Footer } from "@/components/Footer";
+import { PageHero } from "@/components/PageHero";
+import { FadeIn } from "@/components/FadeIn";
+import { getFooterProps } from "@/lib/wordpress-fallbacks";
+import { MINISTRY_PAGES } from "@/lib/subpage-fallbacks";
+import {
+  Users,
+  BookOpen,
+  Baby,
+  HandHeart,
+  Sparkles,
+  Heart,
+  Ear,
+  Globe,
+  Shield,
+  HeartHandshake,
+  ArrowRight,
+  Calendar,
+  type LucideIcon,
+} from "lucide-react";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Ministries | 180 Life Church",
+  description:
+    "Explore our ministries. Life Groups, Students, Kids, Young Adults, Worship, and more. There is a place for everyone at 180 Life Church.",
+};
+
+/* ------------------------------------------------------------------ */
+/* Icon + color mapping for each ministry slug                         */
+/* ------------------------------------------------------------------ */
+
+const iconMap: Record<string, LucideIcon> = {
+  "life-groups": Users,
+  students: BookOpen,
+  "young-adults": Sparkles,
+  kids: Baby,
+  mens: Shield,
+  womens: Heart,
+  missions: Globe,
+  "deaf-ministry": Ear,
+  care: HandHeart,
+  prayer: HandHeart,
+  serving: HandHeart,
+  "marriage-prep": HeartHandshake,
+};
+
+const colorMap: Record<string, string> = {
+  "life-groups": "from-teal/80 to-charcoal/90",
+  students: "from-amber/70 to-charcoal/90",
+  "young-adults": "from-indigo-500/70 to-charcoal/90",
+  kids: "from-pink-500/70 to-charcoal/90",
+  mens: "from-slate-600/80 to-charcoal/90",
+  womens: "from-rose-400/70 to-charcoal/90",
+  missions: "from-emerald-600/70 to-charcoal/90",
+  "deaf-ministry": "from-sky-500/70 to-charcoal/90",
+  care: "from-orange-500/70 to-charcoal/90",
+  prayer: "from-violet-500/70 to-charcoal/90",
+  serving: "from-lime-600/70 to-charcoal/90",
+  "marriage-prep": "from-rose-600/70 to-charcoal/90",
+};
+
+/* ------------------------------------------------------------------ */
+/* Grouped ministry sections                                           */
+/* ------------------------------------------------------------------ */
+
+const MINISTRY_GROUPS = [
+  {
+    label: "Age and Stage",
+    heading: "Connect by",
+    headingAccent: "Age and Stage",
+    description:
+      "Find community with people in your season of life.",
+    featured: "kids",
+    ministries: [
+      "kids",
+      "students",
+      "young-adults",
+      "mens",
+      "womens",
+      "marriage-prep",
+    ],
+  },
+  {
+    label: "Spiritual Growth",
+    heading: "Grow",
+    headingAccent: "Together",
+    description: "Deepen your faith alongside others.",
+    featured: "life-groups",
+    ministries: ["life-groups", "prayer", "deaf-ministry"],
+  },
+  {
+    label: "Outreach",
+    heading: "Serve and",
+    headingAccent: "Care",
+    description:
+      "Use your gifts to love your neighbors and your church.",
+    featured: "serving",
+    ministries: ["serving", "care", "missions"],
+  },
+];
+
+/* Hero card images (only for featured ministries) */
+const heroImages: Record<string, string> = {
+  kids: "/images/ministries/kids.jpg",
+  "life-groups": "/images/ministries/life-groups.jpg",
+  serving: "/images/ministries/serving.jpg",
+};
+
+/* ------------------------------------------------------------------ */
+/* Schedule badge helper                                               */
+/* ------------------------------------------------------------------ */
+
+function ScheduleBadge({ slug }: { slug: string }) {
+  const data = MINISTRY_PAGES[slug];
+  const sched = data?.schedule?.[0];
+  if (!sched) return null;
+
+  return (
+    <span className="text-white/50 text-xs flex items-center gap-1.5 mt-2">
+      <Calendar size={12} className="shrink-0" />
+      {sched.day} &middot; {sched.time}
+    </span>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Hero Card (photo background, col-span-2)                            */
+/* ------------------------------------------------------------------ */
+
+function HeroCard({ slug }: { slug: string }) {
+  const data = MINISTRY_PAGES[slug];
+  if (!data) return null;
+  const Icon = iconMap[slug] ?? HandHeart;
+  const image = heroImages[slug];
+
+  return (
+    <FadeIn className="sm:col-span-2">
+      <a
+        href={`/ministries/${slug}`}
+        className="group relative block rounded-2xl overflow-hidden h-full min-h-[300px] hover:-translate-y-1.5 transition-all duration-500 hover:shadow-2xl hover:shadow-black/20"
+      >
+        {/* Photo background */}
+        {image && (
+          <Image
+            src={image}
+            alt={data.title}
+            fill
+            className="object-cover transition-transform duration-700 group-hover:scale-110"
+            sizes="(max-width: 640px) 100vw, 66vw"
+          />
+        )}
+
+        {/* Gradient overlay */}
+        <div className="absolute inset-0 bg-gradient-to-t from-black/90 via-black/50 to-black/20 group-hover:from-black/95 group-hover:via-black/60 transition-all duration-500" />
+
+        {/* Watermark icon */}
+        <div className="absolute top-4 right-4 opacity-[0.07] group-hover:opacity-[0.12] transition-opacity duration-500">
+          <Icon size={140} className="text-white" strokeWidth={1} />
+        </div>
+
+        {/* Content */}
+        <div className="relative p-8 flex flex-col h-full min-h-[300px] z-10">
+          {/* Top: tag badge */}
+          <div className="flex items-start mb-auto">
+            <span className="text-white/70 text-xs font-semibold tracking-[0.15em] uppercase bg-white/10 px-3 py-1.5 rounded-full backdrop-blur-md border border-white/10">
+              Featured
+            </span>
+          </div>
+
+          {/* Bottom content */}
+          <div className="mt-auto">
+            <h3 className="text-white text-2xl sm:text-3xl font-bold mb-2">
+              {data.title}
+            </h3>
+            <p className="text-white/60 text-sm sm:text-base leading-relaxed mb-1 max-w-lg group-hover:text-white/80 transition-colors duration-300">
+              {data.subtitle}
+            </p>
+            <ScheduleBadge slug={slug} />
+
+            {/* Action row */}
+            <div className="flex items-center gap-2 pt-4 mt-3 border-t border-white/10 group-hover:border-white/20 transition-colors">
+              <span className="text-white/70 text-sm font-medium group-hover:text-amber transition-colors duration-300">
+                Learn More
+              </span>
+              <ArrowRight
+                size={16}
+                className="text-white/40 group-hover:text-amber group-hover:translate-x-1.5 transition-all duration-300"
+              />
+            </div>
+          </div>
+        </div>
+      </a>
+    </FadeIn>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Standard Card (gradient background, 1 column)                       */
+/* ------------------------------------------------------------------ */
+
+function StandardCard({
+  slug,
+  delay = 0,
+}: {
+  slug: string;
+  delay?: number;
+}) {
+  const data = MINISTRY_PAGES[slug];
+  if (!data) return null;
+  const Icon = iconMap[slug] ?? HandHeart;
+  const color = colorMap[slug] ?? "from-charcoal/80 to-charcoal/90";
+
+  return (
+    <FadeIn delay={delay}>
+      <a
+        href={`/ministries/${slug}`}
+        className="group relative block rounded-2xl overflow-hidden h-full min-h-[240px] hover:-translate-y-1.5 transition-all duration-500 hover:shadow-2xl hover:shadow-black/20"
+      >
+        {/* Gradient background */}
+        <div className={`absolute inset-0 bg-gradient-to-br ${color}`} />
+
+        {/* Subtle dot pattern */}
+        <div
+          className="absolute inset-0 opacity-[0.03]"
+          style={{
+            backgroundImage:
+              "radial-gradient(circle at 1px 1px, white 1px, transparent 0)",
+            backgroundSize: "24px 24px",
+          }}
+        />
+
+        {/* Watermark icon */}
+        <div className="absolute top-3 right-3 opacity-[0.08] group-hover:opacity-[0.15] transition-opacity duration-500">
+          <Icon size={100} className="text-white" strokeWidth={1} />
+        </div>
+
+        {/* Content */}
+        <div className="relative p-6 flex flex-col h-full min-h-[240px] z-10">
+          {/* Icon badge */}
+          <span className="flex items-center justify-center w-10 h-10 rounded-full bg-white/10 backdrop-blur-md border border-white/10 mb-auto">
+            <Icon className="text-white" size={18} />
+          </span>
+
+          {/* Bottom content */}
+          <div className="mt-auto">
+            <h3 className="text-white text-lg font-bold mb-1">
+              {data.title}
+            </h3>
+            <p className="text-white/60 text-sm leading-relaxed line-clamp-2 group-hover:text-white/80 transition-colors duration-300">
+              {data.subtitle}
+            </p>
+            <ScheduleBadge slug={slug} />
+
+            {/* Action row */}
+            <div className="flex items-center gap-2 pt-3 mt-2 border-t border-white/10 group-hover:border-white/20 transition-colors">
+              <span className="text-white/70 text-sm font-medium group-hover:text-amber transition-colors duration-300">
+                Learn More
+              </span>
+              <ArrowRight
+                size={14}
+                className="text-white/40 group-hover:text-amber group-hover:translate-x-1.5 transition-all duration-300"
+              />
+            </div>
+          </div>
+        </div>
+      </a>
+    </FadeIn>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Page Component                                                      */
+/* ------------------------------------------------------------------ */
+
+export default function MinistriesPage() {
+  const footerProps = getFooterProps();
+
+  return (
+    <>
+      <Navbar />
+      <PageHero
+        title="Our Ministries"
+        subtitle="There is a place for everyone at 180 Life Church. Explore our ministries and find where you belong."
+      />
+
+      {MINISTRY_GROUPS.map((group, gi) => {
+        const nonFeatured = group.ministries.filter(
+          (s) => s !== group.featured
+        );
+
+        return (
+          <section
+            key={group.label}
+            className={`py-16 sm:py-20 ${
+              gi % 2 === 0 ? "bg-soft-white" : "bg-white"
+            }`}
+          >
+            <div className="max-w-6xl mx-auto px-6">
+              {/* Section header */}
+              <FadeIn>
+                <div className="mb-10">
+                  <span className="text-amber text-sm font-medium tracking-[0.2em] uppercase">
+                    {group.label}
+                  </span>
+                  <h2
+                    className="text-3xl sm:text-4xl font-bold text-charcoal mt-3 mb-3"
+                    style={{ fontFamily: "var(--font-playfair)" }}
+                  >
+                    {group.heading}{" "}
+                    <span className="text-amber">{group.headingAccent}</span>
+                  </h2>
+                  <p className="text-charcoal/60 text-lg max-w-xl">
+                    {group.description}
+                  </p>
+                </div>
+              </FadeIn>
+
+              {/* Grid: hero card (2 cols) + standard cards (1 col each) */}
+              <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                {/* Hero card first */}
+                <HeroCard slug={group.featured} />
+
+                {/* Remaining standard cards */}
+                {nonFeatured.map((slug, i) => (
+                  <StandardCard
+                    key={slug}
+                    slug={slug}
+                    delay={0.05 * (i + 1)}
+                  />
+                ))}
+              </div>
+            </div>
+          </section>
+        );
+      })}
+
+      <Footer {...footerProps} />
+    </>
+  );
+}

--- a/src/app/ministries/prayer/page.tsx
+++ b/src/app/ministries/prayer/page.tsx
@@ -1,0 +1,14 @@
+import { MinistryPageTemplate } from "@/components/templates/MinistryPageTemplate";
+import { MINISTRY_PAGES } from "@/lib/subpage-fallbacks";
+import type { Metadata } from "next";
+
+const data = MINISTRY_PAGES["prayer"];
+
+export const metadata: Metadata = {
+  title: `${data.title} | 180 Life Church`,
+  description: data.subtitle,
+};
+
+export default function PrayerMinistryPage() {
+  return <MinistryPageTemplate data={data} />;
+}

--- a/src/app/ministries/serving/page.tsx
+++ b/src/app/ministries/serving/page.tsx
@@ -1,0 +1,14 @@
+import { MinistryPageTemplate } from "@/components/templates/MinistryPageTemplate";
+import { MINISTRY_PAGES } from "@/lib/subpage-fallbacks";
+import type { Metadata } from "next";
+
+const data = MINISTRY_PAGES["serving"];
+
+export const metadata: Metadata = {
+  title: `${data.title} | 180 Life Church`,
+  description: data.subtitle,
+};
+
+export default function ServingTeamsPage() {
+  return <MinistryPageTemplate data={data} />;
+}

--- a/src/app/ministries/students/page.tsx
+++ b/src/app/ministries/students/page.tsx
@@ -1,0 +1,14 @@
+import { MinistryPageTemplate } from "@/components/templates/MinistryPageTemplate";
+import { MINISTRY_PAGES } from "@/lib/subpage-fallbacks";
+import type { Metadata } from "next";
+
+const data = MINISTRY_PAGES["students"];
+
+export const metadata: Metadata = {
+  title: `${data.title} | 180 Life Church`,
+  description: data.subtitle,
+};
+
+export default function StudentsPage() {
+  return <MinistryPageTemplate data={data} />;
+}

--- a/src/app/ministries/womens/page.tsx
+++ b/src/app/ministries/womens/page.tsx
@@ -1,0 +1,14 @@
+import { MinistryPageTemplate } from "@/components/templates/MinistryPageTemplate";
+import { MINISTRY_PAGES } from "@/lib/subpage-fallbacks";
+import type { Metadata } from "next";
+
+const data = MINISTRY_PAGES["womens"];
+
+export const metadata: Metadata = {
+  title: `${data.title} | 180 Life Church`,
+  description: data.subtitle,
+};
+
+export default function WomensMinistryPage() {
+  return <MinistryPageTemplate data={data} />;
+}

--- a/src/app/ministries/young-adults/page.tsx
+++ b/src/app/ministries/young-adults/page.tsx
@@ -1,0 +1,14 @@
+import { MinistryPageTemplate } from "@/components/templates/MinistryPageTemplate";
+import { MINISTRY_PAGES } from "@/lib/subpage-fallbacks";
+import type { Metadata } from "next";
+
+const data = MINISTRY_PAGES["young-adults"];
+
+export const metadata: Metadata = {
+  title: `${data.title} | 180 Life Church`,
+  description: data.subtitle,
+};
+
+export default function YoungAdultsPage() {
+  return <MinistryPageTemplate data={data} />;
+}

--- a/src/app/new-to-faith/page.tsx
+++ b/src/app/new-to-faith/page.tsx
@@ -1,0 +1,15 @@
+import { ContentPageTemplate } from "@/components/templates/ContentPageTemplate";
+import { CONTENT_PAGES } from "@/lib/subpage-fallbacks";
+import type { Metadata } from "next";
+
+const data = CONTENT_PAGES["new-to-faith"];
+
+export const metadata: Metadata = {
+  title: "New to Faith | 180 Life Church",
+  description:
+    "Did you recently give your life to Christ? We are here to help you start your journey with Bible resources, devotionals, and community.",
+};
+
+export default function NewToFaithPage() {
+  return <ContentPageTemplate data={data} />;
+}

--- a/src/app/new/page.tsx
+++ b/src/app/new/page.tsx
@@ -1,0 +1,204 @@
+import { Navbar } from "@/components/Navbar";
+import { Footer } from "@/components/Footer";
+import { PageHero } from "@/components/PageHero";
+import { FadeIn } from "@/components/FadeIn";
+import { getFooterProps, FALLBACK_SETTINGS } from "@/lib/wordpress-fallbacks";
+import {
+  MapPin,
+  Clock,
+  Heart,
+  Users,
+  Baby,
+  Coffee,
+  CheckCircle,
+} from "lucide-react";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "I'm New | 180 Life Church",
+  description:
+    "Planning your first visit to 180 Life Church? Here is everything you need to know about what to expect, what to wear, and where to go.",
+};
+
+export default function NewHerePage() {
+  const footerProps = getFooterProps();
+  const { contact } = FALLBACK_SETTINGS;
+
+  const whatToExpect = [
+    {
+      icon: Clock,
+      title: "Service Times",
+      description: `We meet every Sunday at 9:00 AM and 11:00 AM. ${contact.doorsOpenText}. Services are about 75 minutes. Please arrive early, especially if you have children, to ensure ample time to check them into kids ministry.`,
+    },
+    {
+      icon: Coffee,
+      title: "Come As You Are",
+      description:
+        "We want you to feel the freedom to come as you are. Some people dress up while others dress casually. Join us in an outfit that you are comfortable in.",
+    },
+    {
+      icon: Users,
+      title: "Guest Center",
+      description:
+        "If you are new, be sure to head over to the Guest Center after church where we have a special gift for you and can answer any of your questions. Join us after service for free coffee and refreshments.",
+    },
+    {
+      icon: Heart,
+      title: "Worship & Teaching",
+      description:
+        "We start with worship, announcements, followed by a message from one of our pastors. Our services are relevant, Bible-based, and practical.",
+    },
+    {
+      icon: Baby,
+      title: "Kids Are Welcome",
+      description:
+        "We have safe, fun, age-appropriate programs for kids from nursery through 5th grade during both services, and middle school programming during our 11 AM service.",
+    },
+    {
+      icon: MapPin,
+      title: "Easy to Find",
+      description: `Our building is located at ${contact.addressLine1}, ${contact.addressLine2}. Look for our signs and our welcoming team in the parking lot.`,
+    },
+  ];
+
+  return (
+    <>
+      <Navbar />
+      <PageHero
+        title="We Saved You a Seat"
+        subtitle="Whether you're exploring faith for the first time or looking for a new church home, you're welcome here."
+      />
+
+      {/* What to Expect */}
+      <section className="bg-soft-white py-16 sm:py-20">
+        <div className="max-w-5xl mx-auto px-6">
+          <FadeIn>
+            <div className="text-center mb-12">
+              <span className="text-amber text-sm font-medium tracking-[0.2em] uppercase">
+                Your First Visit
+              </span>
+              <h2
+                className="text-3xl sm:text-4xl font-bold text-charcoal mt-3"
+                style={{ fontFamily: "var(--font-playfair)" }}
+              >
+                What to <span className="text-amber">Expect</span>
+              </h2>
+            </div>
+          </FadeIn>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {whatToExpect.map((item, i) => {
+              const Icon = item.icon;
+              return (
+                <FadeIn key={item.title} delay={i * 0.05}>
+                  <div className="group bg-white rounded-2xl border border-charcoal/8 p-6 h-full min-h-[220px] flex flex-col hover:-translate-y-1 hover:shadow-lg hover:border-amber/30 transition-all duration-500">
+                    <div className="w-12 h-12 rounded-xl bg-amber/10 flex items-center justify-center mb-4 group-hover:bg-amber/20 group-hover:scale-110 transition-all duration-300">
+                      <Icon className="text-amber" size={22} />
+                    </div>
+                    <h3 className="font-bold text-charcoal mb-2 group-hover:text-amber transition-colors">{item.title}</h3>
+                    <p className="text-charcoal/60 text-sm leading-relaxed mt-auto">
+                      {item.description}
+                    </p>
+                  </div>
+                </FadeIn>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section className="bg-white py-16 sm:py-20">
+        <div className="max-w-3xl mx-auto px-6">
+          <FadeIn>
+            <h2
+              className="text-3xl font-bold text-charcoal mb-10 text-center"
+              style={{ fontFamily: "var(--font-playfair)" }}
+            >
+              Common <span className="text-amber">Questions</span>
+            </h2>
+          </FadeIn>
+          {[
+            {
+              q: "What should I wear?",
+              a: "Whatever you are comfortable in! You will see everything from jeans to suits. There is no dress code.",
+            },
+            {
+              q: "How long is the service?",
+              a: "About 75 minutes. We start with worship music, have a time for announcements, and then hear a message from one of our pastors.",
+            },
+            {
+              q: "Is there parking?",
+              a: "Yes! We have a large parking lot with plenty of space. Our parking team will help guide you.",
+            },
+            {
+              q: "Do I need to bring anything?",
+              a: "Just yourself! We have Bibles available and everything you need will be provided.",
+            },
+            {
+              q: "What about my kids?",
+              a: "We have dedicated kids programs during both services for ages nursery through 5th grade, and middle school during our 11 AM service. All volunteers are background-checked.",
+            },
+            {
+              q: "I just gave my life to Christ. What now?",
+              a: "Congratulations! We have resources to help you grow in your new faith. Visit our New to Faith page or talk to someone at the Guest Center after service.",
+            },
+          ].map((faq, i) => (
+            <FadeIn key={i} delay={i * 0.05}>
+              <div className="flex items-start gap-3 mb-6">
+                <CheckCircle
+                  className="text-amber shrink-0 mt-1"
+                  size={18}
+                />
+                <div>
+                  <p className="font-semibold text-charcoal">{faq.q}</p>
+                  <p className="text-charcoal/60 text-sm mt-1 leading-relaxed">
+                    {faq.a}
+                  </p>
+                </div>
+              </div>
+            </FadeIn>
+          ))}
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section
+        className="py-16 sm:py-20 text-center"
+        style={{
+          background:
+            "radial-gradient(ellipse at 50% 50%, rgba(212, 160, 84, 0.15) 0%, transparent 60%), linear-gradient(to bottom, #1A1A1A, #201C16, #1A1A1A)",
+        }}
+      >
+        <div className="max-w-3xl mx-auto px-6">
+          <FadeIn>
+            <h2
+              className="text-3xl sm:text-4xl font-bold text-white mb-4"
+              style={{ fontFamily: "var(--font-playfair)" }}
+            >
+              We Can&apos;t Wait to Meet You
+            </h2>
+            <p className="text-white/60 text-lg mb-8 max-w-xl mx-auto">
+              Have questions before your visit? We would love to hear from you.
+            </p>
+            <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+              <a
+                href="/contact"
+                className="px-8 py-3.5 bg-amber text-charcoal font-semibold rounded-full hover:bg-amber-light transition-all hover:shadow-lg hover:shadow-amber/25"
+              >
+                Contact Us
+              </a>
+              <a
+                href="/new-to-faith"
+                className="px-8 py-3.5 text-white border border-white/30 font-semibold rounded-full hover:bg-white/10 transition-all"
+              >
+                New to Faith?
+              </a>
+            </div>
+          </FadeIn>
+        </div>
+      </section>
+
+      <Footer hideChecklistBanner {...footerProps} />
+    </>
+  );
+}

--- a/src/app/partnership/page.tsx
+++ b/src/app/partnership/page.tsx
@@ -1,0 +1,14 @@
+import { ContentPageTemplate } from "@/components/templates/ContentPageTemplate";
+import { CONTENT_PAGES } from "@/lib/subpage-fallbacks";
+import type { Metadata } from "next";
+
+const data = CONTENT_PAGES["partnership"];
+
+export const metadata: Metadata = {
+  title: "Partnership | 180 Life Church",
+  description: data.subtitle,
+};
+
+export default function PartnershipPage() {
+  return <ContentPageTemplate data={data} />;
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,126 @@
+import { Navbar } from "@/components/Navbar";
+import { Footer } from "@/components/Footer";
+import { PageHero } from "@/components/PageHero";
+import { FadeIn } from "@/components/FadeIn";
+import { getFooterProps } from "@/lib/wordpress-fallbacks";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy | 180 Life Church",
+  description:
+    "Privacy policy for 180 Life Church. Learn how we collect, use, and protect your personal information.",
+};
+
+export default function PrivacyPage() {
+  const footerProps = getFooterProps();
+
+  return (
+    <>
+      <Navbar />
+      <PageHero
+        title="Privacy Policy"
+        subtitle="Your privacy is important to us."
+        breadcrumbs={[{ label: "Privacy Policy", href: "/privacy" }]}
+      />
+
+      <section className="bg-soft-white py-16 sm:py-20">
+        <div className="max-w-3xl mx-auto px-6">
+          <FadeIn>
+            <div className="prose prose-charcoal max-w-none space-y-6">
+              <p className="text-charcoal/60 text-sm">
+                Last updated: March 2026
+              </p>
+
+              <h2
+                className="text-2xl font-bold text-charcoal"
+                style={{ fontFamily: "var(--font-playfair)" }}
+              >
+                Information We Collect
+              </h2>
+              <p className="text-charcoal/70 leading-relaxed">
+                180 Life Church collects personal information that you
+                voluntarily provide when you fill out forms on our website, such
+                as your name, email address, phone number, and message content.
+                We also collect information when you register for events, submit
+                prayer requests, or sign up for communications.
+              </p>
+
+              <h2
+                className="text-2xl font-bold text-charcoal"
+                style={{ fontFamily: "var(--font-playfair)" }}
+              >
+                How We Use Your Information
+              </h2>
+              <p className="text-charcoal/70 leading-relaxed">
+                We use your information to respond to your inquiries, process
+                event registrations, send communications you have opted into,
+                and improve our website and services. We do not sell, rent, or
+                share your personal information with third parties for marketing
+                purposes.
+              </p>
+
+              <h2
+                className="text-2xl font-bold text-charcoal"
+                style={{ fontFamily: "var(--font-playfair)" }}
+              >
+                Third-Party Services
+              </h2>
+              <p className="text-charcoal/70 leading-relaxed">
+                Our website may use third-party services such as Formspree for
+                form handling, Google Maps for location display, YouTube for
+                video content, and Church Center by Planning Center for event
+                registrations and online giving. These services have their own
+                privacy policies governing how they handle your data.
+              </p>
+
+              <h2
+                className="text-2xl font-bold text-charcoal"
+                style={{ fontFamily: "var(--font-playfair)" }}
+              >
+                Cookies
+              </h2>
+              <p className="text-charcoal/70 leading-relaxed">
+                Our website may use cookies and similar technologies to enhance
+                your browsing experience. You can adjust your browser settings
+                to refuse cookies, though some features may not function
+                properly without them.
+              </p>
+
+              <h2
+                className="text-2xl font-bold text-charcoal"
+                style={{ fontFamily: "var(--font-playfair)" }}
+              >
+                Data Security
+              </h2>
+              <p className="text-charcoal/70 leading-relaxed">
+                We take reasonable measures to protect your personal information
+                from unauthorized access, use, or disclosure. However, no
+                method of transmission over the internet is completely secure.
+              </p>
+
+              <h2
+                className="text-2xl font-bold text-charcoal"
+                style={{ fontFamily: "var(--font-playfair)" }}
+              >
+                Contact Us
+              </h2>
+              <p className="text-charcoal/70 leading-relaxed">
+                If you have questions about this privacy policy, please contact
+                us at{" "}
+                <a
+                  href="mailto:info@180lifechurch.org"
+                  className="text-amber hover:underline"
+                >
+                  info@180lifechurch.org
+                </a>
+                .
+              </p>
+            </div>
+          </FadeIn>
+        </div>
+      </section>
+
+      <Footer hideChecklistBanner {...footerProps} />
+    </>
+  );
+}

--- a/src/app/sermons/[slug]/page.tsx
+++ b/src/app/sermons/[slug]/page.tsx
@@ -1,0 +1,45 @@
+import { SermonSeriesTemplate } from "@/components/templates/SermonSeriesTemplate";
+import { SERMON_SERIES, ALL_SERIES_SLUGS } from "@/lib/subpage-fallbacks";
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateStaticParams() {
+  return ALL_SERIES_SLUGS.map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const series = SERMON_SERIES[slug];
+  if (!series) return {};
+
+  return {
+    title: `${series.title} | Sermons | 180 Life Church`,
+    description: series.subtitle,
+  };
+}
+
+export default async function SermonSeriesPage({ params }: Props) {
+  const { slug } = await params;
+  const series = SERMON_SERIES[slug];
+
+  if (!series) {
+    notFound();
+  }
+
+  // Add related series (all except current)
+  const related = Object.values(SERMON_SERIES)
+    .filter((s) => s.slug !== slug)
+    .map((s) => ({
+      title: s.title,
+      slug: s.slug,
+      image: s.sermons[0]
+        ? `https://i.ytimg.com/vi/${s.sermons[0].youtubeId}/hqdefault.jpg`
+        : "/images/series/placeholder.jpg",
+    }));
+
+  return <SermonSeriesTemplate data={{ ...series, relatedSeries: related }} />;
+}

--- a/src/app/sermons/page.tsx
+++ b/src/app/sermons/page.tsx
@@ -1,0 +1,101 @@
+import Image from "next/image";
+import { Navbar } from "@/components/Navbar";
+import { Footer } from "@/components/Footer";
+import { PageHero } from "@/components/PageHero";
+import { FadeIn } from "@/components/FadeIn";
+import { getFooterProps } from "@/lib/wordpress-fallbacks";
+import { SERMON_SERIES } from "@/lib/subpage-fallbacks";
+import { Play, Youtube } from "lucide-react";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Sermons | 180 Life Church",
+  description:
+    "Watch and listen to sermons from 180 Life Church. Browse our sermon series and catch up on messages you missed.",
+};
+
+export default function SermonsPage() {
+  const footerProps = getFooterProps();
+  const allSeries = Object.values(SERMON_SERIES);
+
+  return (
+    <>
+      <Navbar />
+      <PageHero
+        title="Sermons"
+        subtitle="Missed a Sunday? Catch up on our latest messages and browse our sermon series."
+        breadcrumbs={[{ label: "Sermons", href: "/sermons" }]}
+      />
+
+      {/* Browse by YouTube */}
+      <section className="bg-soft-white py-10">
+        <div className="max-w-3xl mx-auto px-6 text-center">
+          <FadeIn>
+            <a
+              href="https://www.youtube.com/@180lifechurch"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-6 py-3 bg-white border border-charcoal/10 rounded-full text-charcoal font-medium hover:border-amber/30 hover:shadow-md transition-all"
+            >
+              <Youtube className="text-red-600" size={20} />
+              Watch on YouTube
+            </a>
+          </FadeIn>
+        </div>
+      </section>
+
+      {/* Series Grid */}
+      <section className="bg-white py-16 sm:py-20">
+        <div className="max-w-6xl mx-auto px-6">
+          <FadeIn>
+            <h2
+              className="text-3xl font-bold text-charcoal mb-10"
+              style={{ fontFamily: "var(--font-playfair)" }}
+            >
+              Sermon <span className="text-amber">Series</span>
+            </h2>
+          </FadeIn>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {allSeries.map((series, i) => (
+              <FadeIn key={series.slug} delay={i * 0.05}>
+                <a
+                  href={`/sermons/${series.slug}`}
+                  className="group block rounded-2xl overflow-hidden border border-charcoal/8 bg-white hover:shadow-lg transition-shadow"
+                >
+                  <div className="relative aspect-video bg-charcoal/5">
+                    {series.sermons[0] && (
+                      <Image
+                        src={`https://i.ytimg.com/vi/${series.sermons[0].youtubeId}/hqdefault.jpg`}
+                        alt={series.title}
+                        fill
+                        className="object-cover"
+                      />
+                    )}
+                    <div className="absolute inset-0 bg-black/20 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+                      <div className="w-14 h-14 rounded-full bg-amber flex items-center justify-center">
+                        <Play className="text-charcoal ml-1" size={24} />
+                      </div>
+                    </div>
+                  </div>
+                  <div className="p-5">
+                    <h3 className="font-bold text-charcoal group-hover:text-amber transition-colors text-lg">
+                      {series.title}
+                    </h3>
+                    <p className="text-charcoal/50 text-sm mt-1">
+                      {series.subtitle}
+                    </p>
+                    <p className="text-amber text-xs font-medium mt-3">
+                      {series.sermons.length} message{series.sermons.length !== 1 ? "s" : ""}
+                    </p>
+                  </div>
+                </a>
+              </FadeIn>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <Footer hideChecklistBanner {...footerProps} />
+    </>
+  );
+}

--- a/src/app/serving/page.tsx
+++ b/src/app/serving/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function ServePage() {
+  redirect("/ministries/serving");
+}

--- a/src/app/stories/page.tsx
+++ b/src/app/stories/page.tsx
@@ -1,0 +1,14 @@
+import { ContentPageTemplate } from "@/components/templates/ContentPageTemplate";
+import { CONTENT_PAGES } from "@/lib/subpage-fallbacks";
+import type { Metadata } from "next";
+
+const data = CONTENT_PAGES["stories"];
+
+export const metadata: Metadata = {
+  title: "Stories | 180 Life Church",
+  description: data.subtitle,
+};
+
+export default function StoriesPage() {
+  return <ContentPageTemplate data={data} />;
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,123 @@
+import { Navbar } from "@/components/Navbar";
+import { Footer } from "@/components/Footer";
+import { PageHero } from "@/components/PageHero";
+import { FadeIn } from "@/components/FadeIn";
+import { getFooterProps } from "@/lib/wordpress-fallbacks";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Terms of Use | 180 Life Church",
+  description:
+    "Terms of use for the 180 Life Church website.",
+};
+
+export default function TermsPage() {
+  const footerProps = getFooterProps();
+
+  return (
+    <>
+      <Navbar />
+      <PageHero
+        title="Terms of Use"
+        subtitle="Please review the terms governing use of this website."
+        breadcrumbs={[{ label: "Terms", href: "/terms" }]}
+      />
+
+      <section className="bg-soft-white py-16 sm:py-20">
+        <div className="max-w-3xl mx-auto px-6">
+          <FadeIn>
+            <div className="prose prose-charcoal max-w-none space-y-6">
+              <p className="text-charcoal/60 text-sm">
+                Last updated: March 2026
+              </p>
+
+              <h2
+                className="text-2xl font-bold text-charcoal"
+                style={{ fontFamily: "var(--font-playfair)" }}
+              >
+                Acceptance of Terms
+              </h2>
+              <p className="text-charcoal/70 leading-relaxed">
+                By accessing and using the 180 Life Church website, you agree to
+                comply with and be bound by these terms of use. If you do not
+                agree, please do not use this website.
+              </p>
+
+              <h2
+                className="text-2xl font-bold text-charcoal"
+                style={{ fontFamily: "var(--font-playfair)" }}
+              >
+                Use of Content
+              </h2>
+              <p className="text-charcoal/70 leading-relaxed">
+                All content on this website, including text, images, graphics,
+                and videos, is the property of 180 Life Church or its content
+                providers. You may view and download content for personal,
+                non-commercial use only. Reproduction, distribution, or
+                modification of content without prior written permission is
+                prohibited.
+              </p>
+
+              <h2
+                className="text-2xl font-bold text-charcoal"
+                style={{ fontFamily: "var(--font-playfair)" }}
+              >
+                External Links
+              </h2>
+              <p className="text-charcoal/70 leading-relaxed">
+                This website may contain links to third-party websites. These
+                links are provided for convenience and do not imply endorsement.
+                180 Life Church is not responsible for the content or privacy
+                practices of external sites.
+              </p>
+
+              <h2
+                className="text-2xl font-bold text-charcoal"
+                style={{ fontFamily: "var(--font-playfair)" }}
+              >
+                Disclaimer
+              </h2>
+              <p className="text-charcoal/70 leading-relaxed">
+                This website is provided &quot;as is&quot; without warranties of
+                any kind, either express or implied. 180 Life Church does not
+                guarantee that the website will be available at all times or that
+                the content is free of errors.
+              </p>
+
+              <h2
+                className="text-2xl font-bold text-charcoal"
+                style={{ fontFamily: "var(--font-playfair)" }}
+              >
+                Changes to Terms
+              </h2>
+              <p className="text-charcoal/70 leading-relaxed">
+                180 Life Church reserves the right to modify these terms at any
+                time. Continued use of the website following any changes
+                constitutes acceptance of the updated terms.
+              </p>
+
+              <h2
+                className="text-2xl font-bold text-charcoal"
+                style={{ fontFamily: "var(--font-playfair)" }}
+              >
+                Contact
+              </h2>
+              <p className="text-charcoal/70 leading-relaxed">
+                Questions about these terms can be directed to{" "}
+                <a
+                  href="mailto:info@180lifechurch.org"
+                  className="text-amber hover:underline"
+                >
+                  info@180lifechurch.org
+                </a>
+                .
+              </p>
+            </div>
+          </FadeIn>
+        </div>
+      </section>
+
+      <Footer hideChecklistBanner {...footerProps} />
+    </>
+  );
+}

--- a/src/components/BfcacheReloader.tsx
+++ b/src/components/BfcacheReloader.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Fixes Framer Motion animations that get stuck at opacity: 0 after
+ * Next.js App Router client-side back/forward navigation.
+ *
+ * The App Router restores a cached React tree on popstate without
+ * remounting components, so `initial={{ opacity: 0 }}` stays stuck
+ * because `animate={{ opacity: 1 }}` already fired and won't replay.
+ *
+ * Two-pronged fix:
+ * 1. bfcache: full page reload on `pageshow` with `persisted: true`
+ * 2. SPA back/forward: URL-change detection via polling, then force
+ *    all stuck opacity-0 elements to visible. Polling is used because
+ *    Next.js intercepts popstate before custom listeners can act on
+ *    the fully-rendered DOM.
+ */
+export function BfcacheReloader() {
+  useEffect(() => {
+    // 1. Handle actual bfcache restores (full page freeze/thaw)
+    const handlePageShow = (e: PageTransitionEvent) => {
+      if (e.persisted) {
+        window.location.reload();
+      }
+    };
+    window.addEventListener("pageshow", handlePageShow);
+
+    // 2. Detect URL changes and fix stuck Framer Motion elements
+    let lastUrl = window.location.href;
+
+    const checkUrl = setInterval(() => {
+      const currentUrl = window.location.href;
+      if (currentUrl !== lastUrl) {
+        lastUrl = currentUrl;
+        // Use setTimeout to let Next.js finish rendering
+        setTimeout(revealStuckElements, 100);
+      }
+    }, 200);
+
+    return () => {
+      window.removeEventListener("pageshow", handlePageShow);
+      clearInterval(checkUrl);
+    };
+  }, []);
+
+  return null;
+}
+
+/**
+ * Finds all elements with inline `opacity: 0` (set by Framer Motion's
+ * `initial` prop) and smoothly transitions them to visible.
+ */
+function revealStuckElements() {
+  document.querySelectorAll("[style]").forEach((el) => {
+    if (!(el instanceof HTMLElement)) return;
+
+    const isStuck = el.style.opacity === "0";
+    const hasOffset =
+      el.style.transform &&
+      (el.style.transform.includes("translate") ||
+        el.style.transform.includes("scale"));
+
+    if (isStuck || hasOffset) {
+      el.style.transition =
+        "opacity 0.35s ease-out, transform 0.35s ease-out";
+
+      if (isStuck) {
+        el.style.opacity = "1";
+      }
+      if (hasOffset) {
+        el.style.transform = "none";
+      }
+    }
+  });
+}

--- a/src/components/BfcacheReloader.tsx
+++ b/src/components/BfcacheReloader.tsx
@@ -12,10 +12,9 @@ import { useEffect } from "react";
  *
  * Two-pronged fix:
  * 1. bfcache: full page reload on `pageshow` with `persisted: true`
- * 2. SPA back/forward: URL-change detection via polling, then force
- *    all stuck opacity-0 elements to visible. Polling is used because
- *    Next.js intercepts popstate before custom listeners can act on
- *    the fully-rendered DOM.
+ * 2. SPA back/forward: on `popstate` (only fires for browser back/forward,
+ *    NOT for forward link clicks), wait for Next.js to render, then
+ *    smoothly reveal any elements still stuck at opacity: 0.
  */
 export function BfcacheReloader() {
   useEffect(() => {
@@ -25,23 +24,21 @@ export function BfcacheReloader() {
         window.location.reload();
       }
     };
+
+    // 2. Handle SPA back/forward navigation (popstate only fires on
+    //    browser back/forward buttons, not on Link clicks or router.push)
+    const handlePopState = () => {
+      // Give Next.js time to swap in the cached page and settle.
+      // Use setTimeout (not rAF) because rAF is throttled in background tabs.
+      setTimeout(revealStuckElements, 300);
+    };
+
     window.addEventListener("pageshow", handlePageShow);
-
-    // 2. Detect URL changes and fix stuck Framer Motion elements
-    let lastUrl = window.location.href;
-
-    const checkUrl = setInterval(() => {
-      const currentUrl = window.location.href;
-      if (currentUrl !== lastUrl) {
-        lastUrl = currentUrl;
-        // Use setTimeout to let Next.js finish rendering
-        setTimeout(revealStuckElements, 100);
-      }
-    }, 200);
+    window.addEventListener("popstate", handlePopState);
 
     return () => {
       window.removeEventListener("pageshow", handlePageShow);
-      clearInterval(checkUrl);
+      window.removeEventListener("popstate", handlePopState);
     };
   }, []);
 
@@ -49,29 +46,17 @@ export function BfcacheReloader() {
 }
 
 /**
- * Finds all elements with inline `opacity: 0` (set by Framer Motion's
- * `initial` prop) and smoothly transitions them to visible.
+ * Finds elements with inline `opacity: 0` (set by Framer Motion's
+ * `initial` prop) and smoothly fades them in. Only touches opacity,
+ * not transforms, to avoid interfering with scroll-driven motion
+ * values or layout.
  */
 function revealStuckElements() {
   document.querySelectorAll("[style]").forEach((el) => {
     if (!(el instanceof HTMLElement)) return;
-
-    const isStuck = el.style.opacity === "0";
-    const hasOffset =
-      el.style.transform &&
-      (el.style.transform.includes("translate") ||
-        el.style.transform.includes("scale"));
-
-    if (isStuck || hasOffset) {
-      el.style.transition =
-        "opacity 0.35s ease-out, transform 0.35s ease-out";
-
-      if (isStuck) {
-        el.style.opacity = "1";
-      }
-      if (hasOffset) {
-        el.style.transform = "none";
-      }
+    if (el.style.opacity === "0") {
+      el.style.transition = "opacity 0.4s ease-out";
+      el.style.opacity = "1";
     }
   });
 }

--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -1,0 +1,27 @@
+import { ChevronRight } from "lucide-react";
+
+interface BreadcrumbProps {
+  items: { label: string; href: string }[];
+}
+
+export function Breadcrumb({ items }: BreadcrumbProps) {
+  return (
+    <nav aria-label="Breadcrumb" className="flex items-center justify-center gap-2 text-sm mb-4">
+      <a href="/" className="text-white/40 hover:text-amber transition-colors">
+        Home
+      </a>
+      {items.map((item, i) => (
+        <span key={item.href} className="flex items-center gap-2">
+          <ChevronRight className="text-white/20" size={14} />
+          {i === items.length - 1 ? (
+            <span className="text-amber">{item.label}</span>
+          ) : (
+            <a href={item.href} className="text-white/40 hover:text-amber transition-colors">
+              {item.label}
+            </a>
+          )}
+        </span>
+      ))}
+    </nav>
+  );
+}

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useState, FormEvent } from "react";
+import { Send, CheckCircle } from "lucide-react";
+
+interface ContactFormProps {
+  formId?: string;
+  heading?: string;
+  description?: string;
+}
+
+export function ContactForm({
+  formId = "xpqynyda",
+  heading = "Send Us a Message",
+  description,
+}: ContactFormProps) {
+  const [submitted, setSubmitted] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setSubmitting(true);
+    const form = e.currentTarget;
+    const data = new FormData(form);
+
+    const res = await fetch(`https://formspree.io/f/${formId}`, {
+      method: "POST",
+      body: data,
+      headers: { Accept: "application/json" },
+    });
+
+    setSubmitting(false);
+    if (res.ok) {
+      setSubmitted(true);
+      form.reset();
+    }
+  }
+
+  if (submitted) {
+    return (
+      <div className="bg-white rounded-2xl border border-charcoal/8 p-10 text-center">
+        <div className="w-16 h-16 rounded-full bg-green-100 flex items-center justify-center mx-auto mb-4">
+          <CheckCircle className="text-green-600" size={32} />
+        </div>
+        <h3 className="text-xl font-bold text-charcoal mb-2">Message Sent!</h3>
+        <p className="text-charcoal/60">
+          Thank you for reaching out. We&apos;ll get back to you soon.
+        </p>
+        <button
+          onClick={() => setSubmitted(false)}
+          className="mt-6 text-amber hover:text-amber-light text-sm font-medium transition-colors"
+        >
+          Send another message
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-2xl border border-charcoal/8 p-8">
+      {heading && (
+        <h3
+          className="text-2xl font-bold text-charcoal mb-2"
+          style={{ fontFamily: "var(--font-playfair)" }}
+        >
+          {heading}
+        </h3>
+      )}
+      {description && (
+        <p className="text-charcoal/60 mb-6">{description}</p>
+      )}
+      <form onSubmit={handleSubmit} className="space-y-5">
+        <div className="grid sm:grid-cols-2 gap-5">
+          <div>
+            <label htmlFor="name" className="block text-sm font-medium text-charcoal mb-1.5">
+              Name *
+            </label>
+            <input
+              id="name"
+              name="name"
+              type="text"
+              required
+              className="w-full px-4 py-3 rounded-xl border border-charcoal/15 bg-soft-white text-charcoal placeholder:text-charcoal/30 focus:outline-none focus:ring-2 focus:ring-amber/50 focus:border-amber transition-all"
+              placeholder="Your name"
+            />
+          </div>
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-charcoal mb-1.5">
+              Email *
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              required
+              className="w-full px-4 py-3 rounded-xl border border-charcoal/15 bg-soft-white text-charcoal placeholder:text-charcoal/30 focus:outline-none focus:ring-2 focus:ring-amber/50 focus:border-amber transition-all"
+              placeholder="you@email.com"
+            />
+          </div>
+        </div>
+        <div>
+          <label htmlFor="phone" className="block text-sm font-medium text-charcoal mb-1.5">
+            Phone (optional)
+          </label>
+          <input
+            id="phone"
+            name="phone"
+            type="tel"
+            className="w-full px-4 py-3 rounded-xl border border-charcoal/15 bg-soft-white text-charcoal placeholder:text-charcoal/30 focus:outline-none focus:ring-2 focus:ring-amber/50 focus:border-amber transition-all"
+            placeholder="(860) 555-1234"
+          />
+        </div>
+        <div>
+          <label htmlFor="subject" className="block text-sm font-medium text-charcoal mb-1.5">
+            Subject
+          </label>
+          <select
+            id="subject"
+            name="subject"
+            className="w-full px-4 py-3 rounded-xl border border-charcoal/15 bg-soft-white text-charcoal focus:outline-none focus:ring-2 focus:ring-amber/50 focus:border-amber transition-all"
+          >
+            <option value="general">General Inquiry</option>
+            <option value="visit">Planning a Visit</option>
+            <option value="prayer">Prayer Request</option>
+            <option value="volunteer">I Want to Serve</option>
+            <option value="groups">Life Groups</option>
+            <option value="other">Other</option>
+          </select>
+        </div>
+        <div>
+          <label htmlFor="message" className="block text-sm font-medium text-charcoal mb-1.5">
+            Message *
+          </label>
+          <textarea
+            id="message"
+            name="message"
+            required
+            rows={5}
+            className="w-full px-4 py-3 rounded-xl border border-charcoal/15 bg-soft-white text-charcoal placeholder:text-charcoal/30 focus:outline-none focus:ring-2 focus:ring-amber/50 focus:border-amber transition-all resize-none"
+            placeholder="How can we help?"
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={submitting}
+          className="inline-flex items-center gap-2 px-8 py-3.5 bg-amber text-charcoal font-semibold rounded-full hover:bg-amber-light transition-all hover:shadow-lg hover:shadow-amber/25 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {submitting ? "Sending..." : "Send Message"}
+          <Send size={16} />
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/components/ContentSection.tsx
+++ b/src/components/ContentSection.tsx
@@ -1,0 +1,97 @@
+import Image from "next/image";
+import { ReactNode } from "react";
+import { FadeIn } from "./FadeIn";
+
+interface ContentSectionProps {
+  label?: string;
+  heading: string;
+  headingAccent?: string;
+  body: string | string[];
+  image?: { src: string; alt: string; position?: "left" | "right" };
+  children?: ReactNode;
+  background?: "white" | "soft-white" | "dark";
+}
+
+const bgMap = {
+  white: "bg-white",
+  "soft-white": "bg-soft-white",
+  dark: "bg-charcoal text-white",
+};
+
+export function ContentSection({
+  label,
+  heading,
+  headingAccent,
+  body,
+  image,
+  children,
+  background = "white",
+}: ContentSectionProps) {
+  const paragraphs = Array.isArray(body) ? body : [body];
+  const isDark = background === "dark";
+  const imgPosition = image?.position ?? "right";
+
+  return (
+    <section className={`${bgMap[background]} py-16 sm:py-20`}>
+      <div className="max-w-6xl mx-auto px-6">
+        <div
+          className={`flex flex-col ${
+            image ? "lg:flex-row lg:items-center lg:gap-16" : ""
+          } ${image && imgPosition === "left" ? "lg:flex-row-reverse" : ""}`}
+        >
+          {/* Text content */}
+          <div className={image ? "lg:w-1/2" : "max-w-3xl mx-auto"}>
+            {label && (
+              <FadeIn>
+                <span className="text-amber text-sm font-medium tracking-[0.2em] uppercase">
+                  {label}
+                </span>
+              </FadeIn>
+            )}
+            <FadeIn delay={0.1}>
+              <h2
+                className={`text-3xl sm:text-4xl font-bold mt-3 mb-6 ${
+                  isDark ? "text-white" : "text-charcoal"
+                }`}
+                style={{ fontFamily: "var(--font-playfair)" }}
+              >
+                {heading}{" "}
+                {headingAccent && <span className="text-amber">{headingAccent}</span>}
+              </h2>
+            </FadeIn>
+            {paragraphs.map((p, i) => (
+              <FadeIn key={i} delay={0.15 + i * 0.05}>
+                <p
+                  className={`leading-relaxed mb-4 ${
+                    isDark ? "text-white/60" : "text-charcoal/70"
+                  }`}
+                >
+                  {p}
+                </p>
+              </FadeIn>
+            ))}
+            {children && <FadeIn delay={0.25}>{children}</FadeIn>}
+          </div>
+
+          {/* Image */}
+          {image && (
+            <FadeIn
+              delay={0.2}
+              direction={imgPosition === "right" ? "left" : "right"}
+              className="lg:w-1/2 mt-10 lg:mt-0"
+            >
+              <div className="relative aspect-[4/3] rounded-2xl overflow-hidden">
+                <Image
+                  src={image.src}
+                  alt={image.alt}
+                  fill
+                  className="object-cover"
+                />
+              </div>
+            </FadeIn>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -93,7 +93,9 @@ export function Events({ events }: EventsProps) {
         <FadeIn delay={0.4}>
           <div className="text-center mt-12">
             <a
-              href="#all-events"
+              href="https://180lifechurch.churchcenter.com/registrations"
+              target="_blank"
+              rel="noopener noreferrer"
               className="inline-flex items-center text-amber-dark font-semibold hover:text-amber transition-colors group text-lg"
             >
               View All Events

--- a/src/components/FadeIn.tsx
+++ b/src/components/FadeIn.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { ReactNode } from "react";
+import { ReactNode, useEffect, useState } from "react";
 
 interface FadeInProps {
   children: ReactNode;
@@ -18,6 +18,19 @@ export function FadeIn({
   className,
   duration = 0.6,
 }: FadeInProps) {
+  const [isBfcache, setIsBfcache] = useState(false);
+
+  useEffect(() => {
+    const handlePageShow = (e: PageTransitionEvent) => {
+      // persisted = true means the page was restored from bfcache
+      if (e.persisted) {
+        setIsBfcache(true);
+      }
+    };
+    window.addEventListener("pageshow", handlePageShow);
+    return () => window.removeEventListener("pageshow", handlePageShow);
+  }, []);
+
   const directionOffset = {
     up: { y: 30 },
     down: { y: -30 },
@@ -25,6 +38,11 @@ export function FadeIn({
     right: { x: -30 },
     none: {},
   };
+
+  // If restored from bfcache, skip animation entirely — show content immediately
+  if (isBfcache) {
+    return <div className={className}>{children}</div>;
+  }
 
   return (
     <motion.div

--- a/src/components/FadeIn.tsx
+++ b/src/components/FadeIn.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { ReactNode, useEffect, useState } from "react";
+import { ReactNode } from "react";
 
 interface FadeInProps {
   children: ReactNode;
@@ -18,19 +18,6 @@ export function FadeIn({
   className,
   duration = 0.6,
 }: FadeInProps) {
-  const [isBfcache, setIsBfcache] = useState(false);
-
-  useEffect(() => {
-    const handlePageShow = (e: PageTransitionEvent) => {
-      // persisted = true means the page was restored from bfcache
-      if (e.persisted) {
-        setIsBfcache(true);
-      }
-    };
-    window.addEventListener("pageshow", handlePageShow);
-    return () => window.removeEventListener("pageshow", handlePageShow);
-  }, []);
-
   const directionOffset = {
     up: { y: 30 },
     down: { y: -30 },
@@ -38,11 +25,6 @@ export function FadeIn({
     right: { x: -30 },
     none: {},
   };
-
-  // If restored from bfcache, skip animation entirely — show content immediately
-  if (isBfcache) {
-    return <div className={className}>{children}</div>;
-  }
 
   return (
     <motion.div

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,19 +3,22 @@ import { Logo } from "./Logo";
 import type { WPContactData, WPSocialData } from "@/lib/wordpress-types";
 
 const quickLinks = [
-  { label: "About", href: "#about" },
-  { label: "Services", href: "#services" },
-  { label: "Ministries", href: "#ministries" },
-  { label: "Events", href: "#events" },
-  { label: "Sermons", href: "#watch" },
-  { label: "Give", href: "#give" },
+  { label: "About", href: "/about" },
+  { label: "Leadership", href: "/leadership" },
+  { label: "Services", href: "/#services" },
+  { label: "Ministries", href: "/ministries" },
+  { label: "Sermons", href: "/sermons" },
+  { label: "Give", href: "/give" },
 ];
 
 const connectLinks = [
-  { label: "Plan a Visit", href: "#visit" },
-  { label: "Life Groups", href: "#groups" },
-  { label: "Serve", href: "#serve" },
-  { label: "Prayer Request", href: "#prayer" },
+  { label: "Plan a Visit", href: "/new" },
+  { label: "Partnership", href: "/partnership" },
+  { label: "Baptism", href: "/baptism" },
+  { label: "Life Groups", href: "/ministries/life-groups" },
+  { label: "Serve", href: "/ministries/serving" },
+  { label: "Stories", href: "/stories" },
+  { label: "Prayer Request", href: "/contact" },
 ];
 
 interface FooterProps {
@@ -189,13 +192,13 @@ export function Footer({
             </p>
             <div className="flex items-center gap-6">
               <a
-                href="#privacy"
+                href="/privacy"
                 className="text-white/30 hover:text-white/50 text-sm transition-colors"
               >
                 Privacy Policy
               </a>
               <a
-                href="#terms"
+                href="/terms"
                 className="text-white/30 hover:text-white/50 text-sm transition-colors"
               >
                 Terms

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -17,20 +17,10 @@ interface HeroProps {
 
 export function Hero({ hero }: HeroProps) {
   const [wordIndex, setWordIndex] = useState(0);
-  const [isBfcache, setIsBfcache] = useState(false);
   const { scrollY } = useScroll();
 
   // Hero logo: smooth fade out over a wide scroll range
   const heroLogoOpacity = useTransform(scrollY, [0, 100, 400], [1, 0.85, 0]);
-
-  // Detect bfcache restore (back button) — skip entrance animations
-  useEffect(() => {
-    const handlePageShow = (e: PageTransitionEvent) => {
-      if (e.persisted) setIsBfcache(true);
-    };
-    window.addEventListener("pageshow", handlePageShow);
-    return () => window.removeEventListener("pageshow", handlePageShow);
-  }, []);
 
   // Cycle words
   useEffect(() => {
@@ -64,9 +54,9 @@ export function Hero({ hero }: HeroProps) {
           style={{ opacity: heroLogoOpacity }}
         >
           <motion.div
-            initial={isBfcache ? false : { opacity: 0, scale: 0.8, y: 20 }}
+            initial={{ opacity: 0, scale: 0.8, y: 20 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
-            transition={{ duration: isBfcache ? 0 : 1, delay: isBfcache ? 0 : 0.1, ease: "easeOut" }}
+            transition={{ duration: 1, delay: 0.1, ease: "easeOut" }}
           >
             <Image
               src="/images/logo.png"
@@ -80,9 +70,9 @@ export function Hero({ hero }: HeroProps) {
         </motion.div>
 
         <motion.div
-          initial={isBfcache ? false : { opacity: 0, y: 20 }}
+          initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: isBfcache ? 0 : 0.8, delay: isBfcache ? 0 : 0.3 }}
+          transition={{ duration: 0.8, delay: 0.3 }}
           className="mb-6"
         >
           <span className="inline-block text-amber/90 text-sm font-medium tracking-[0.3em] uppercase">
@@ -91,9 +81,9 @@ export function Hero({ hero }: HeroProps) {
         </motion.div>
 
         <motion.h1
-          initial={isBfcache ? false : { opacity: 0, y: 30 }}
+          initial={{ opacity: 0, y: 30 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: isBfcache ? 0 : 0.8, delay: isBfcache ? 0 : 0.5 }}
+          transition={{ duration: 0.8, delay: 0.5 }}
           className="text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-bold text-white leading-[1.1] mb-8"
           style={{ fontFamily: "var(--font-playfair)" }}
         >
@@ -116,18 +106,18 @@ export function Hero({ hero }: HeroProps) {
         </motion.h1>
 
         <motion.p
-          initial={isBfcache ? false : { opacity: 0, y: 20 }}
+          initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: isBfcache ? 0 : 0.8, delay: isBfcache ? 0 : 0.7 }}
+          transition={{ duration: 0.8, delay: 0.7 }}
           className="text-white/70 text-lg sm:text-xl max-w-2xl mx-auto mb-12 leading-relaxed"
         >
           {hero.description}
         </motion.p>
 
         <motion.div
-          initial={isBfcache ? false : { opacity: 0, y: 20 }}
+          initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: isBfcache ? 0 : 0.8, delay: isBfcache ? 0 : 0.9 }}
+          transition={{ duration: 0.8, delay: 0.9 }}
           className="flex flex-col sm:flex-row gap-4 justify-center"
         >
           <a
@@ -150,9 +140,9 @@ export function Hero({ hero }: HeroProps) {
 
       {/* Scroll indicator */}
       <motion.div
-        initial={isBfcache ? false : { opacity: 0 }}
+        initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
-        transition={{ delay: isBfcache ? 0 : 1.5, duration: isBfcache ? 0 : 1 }}
+        transition={{ delay: 1.5, duration: 1 }}
         className="absolute bottom-8 left-1/2 -translate-x-1/2"
       >
         <motion.div

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -17,10 +17,20 @@ interface HeroProps {
 
 export function Hero({ hero }: HeroProps) {
   const [wordIndex, setWordIndex] = useState(0);
+  const [isBfcache, setIsBfcache] = useState(false);
   const { scrollY } = useScroll();
 
   // Hero logo: smooth fade out over a wide scroll range
   const heroLogoOpacity = useTransform(scrollY, [0, 100, 400], [1, 0.85, 0]);
+
+  // Detect bfcache restore (back button) — skip entrance animations
+  useEffect(() => {
+    const handlePageShow = (e: PageTransitionEvent) => {
+      if (e.persisted) setIsBfcache(true);
+    };
+    window.addEventListener("pageshow", handlePageShow);
+    return () => window.removeEventListener("pageshow", handlePageShow);
+  }, []);
 
   // Cycle words
   useEffect(() => {
@@ -54,9 +64,9 @@ export function Hero({ hero }: HeroProps) {
           style={{ opacity: heroLogoOpacity }}
         >
           <motion.div
-            initial={{ opacity: 0, scale: 0.8, y: 20 }}
+            initial={isBfcache ? false : { opacity: 0, scale: 0.8, y: 20 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
-            transition={{ duration: 1, delay: 0.1, ease: "easeOut" }}
+            transition={{ duration: isBfcache ? 0 : 1, delay: isBfcache ? 0 : 0.1, ease: "easeOut" }}
           >
             <Image
               src="/images/logo.png"
@@ -70,9 +80,9 @@ export function Hero({ hero }: HeroProps) {
         </motion.div>
 
         <motion.div
-          initial={{ opacity: 0, y: 20 }}
+          initial={isBfcache ? false : { opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 0.3 }}
+          transition={{ duration: isBfcache ? 0 : 0.8, delay: isBfcache ? 0 : 0.3 }}
           className="mb-6"
         >
           <span className="inline-block text-amber/90 text-sm font-medium tracking-[0.3em] uppercase">
@@ -81,9 +91,9 @@ export function Hero({ hero }: HeroProps) {
         </motion.div>
 
         <motion.h1
-          initial={{ opacity: 0, y: 30 }}
+          initial={isBfcache ? false : { opacity: 0, y: 30 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 0.5 }}
+          transition={{ duration: isBfcache ? 0 : 0.8, delay: isBfcache ? 0 : 0.5 }}
           className="text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-bold text-white leading-[1.1] mb-8"
           style={{ fontFamily: "var(--font-playfair)" }}
         >
@@ -106,18 +116,18 @@ export function Hero({ hero }: HeroProps) {
         </motion.h1>
 
         <motion.p
-          initial={{ opacity: 0, y: 20 }}
+          initial={isBfcache ? false : { opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 0.7 }}
+          transition={{ duration: isBfcache ? 0 : 0.8, delay: isBfcache ? 0 : 0.7 }}
           className="text-white/70 text-lg sm:text-xl max-w-2xl mx-auto mb-12 leading-relaxed"
         >
           {hero.description}
         </motion.p>
 
         <motion.div
-          initial={{ opacity: 0, y: 20 }}
+          initial={isBfcache ? false : { opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 0.9 }}
+          transition={{ duration: isBfcache ? 0 : 0.8, delay: isBfcache ? 0 : 0.9 }}
           className="flex flex-col sm:flex-row gap-4 justify-center"
         >
           <a
@@ -140,9 +150,9 @@ export function Hero({ hero }: HeroProps) {
 
       {/* Scroll indicator */}
       <motion.div
-        initial={{ opacity: 0 }}
+        initial={isBfcache ? false : { opacity: 0 }}
         animate={{ opacity: 1 }}
-        transition={{ delay: 1.5, duration: 1 }}
+        transition={{ delay: isBfcache ? 0 : 1.5, duration: isBfcache ? 0 : 1 }}
         className="absolute bottom-8 left-1/2 -translate-x-1/2"
       >
         <motion.div

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -5,47 +5,57 @@ import { motion, AnimatePresence, useScroll, useTransform } from "framer-motion"
 import { Menu, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Logo } from "./Logo";
+import { usePathname } from "next/navigation";
 
 const navLinks = [
-  { label: "About", href: "#about" },
-  { label: "Services", href: "#services" },
-  { label: "Ministries", href: "#ministries" },
-  { label: "Events", href: "#events" },
-  { label: "Contact", href: "#contact" },
+  { label: "About", href: "/about" },
+  { label: "Leadership", href: "/leadership" },
+  { label: "Ministries", href: "/ministries" },
+  { label: "Sermons", href: "/sermons" },
+  { label: "Contact", href: "/contact" },
 ];
 
 export function Navbar() {
   const [scrolled, setScrolled] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
+  const pathname = usePathname();
+  const isHome = pathname === "/";
   const { scrollY } = useScroll();
 
-  // Navbar logo fades in smoothly as hero logo fades out
+  // On homepage: navbar logo fades in as hero logo fades out
+  // On subpages: always visible
   const navLogoOpacity = useTransform(scrollY, [150, 400], [0, 1]);
 
   useEffect(() => {
+    // On subpages, always show scrolled state immediately
     const handleScroll = () => setScrolled(window.scrollY > 50);
+    handleScroll(); // Run on mount to catch restored scroll positions (back button)
     window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
+  }, [pathname]);
+
+  // Close mobile menu on route change
+  useEffect(() => {
+    setMobileOpen(false);
+  }, [pathname]);
 
   return (
     <motion.header
-      initial={{ y: -100 }}
+      initial={false}
       animate={{ y: 0 }}
-      transition={{ duration: 0.6, ease: "easeOut" }}
       className={cn(
         "fixed top-0 left-0 right-0 z-50 transition-all duration-500",
-        scrolled
+        scrolled || !isHome
           ? "bg-charcoal/95 backdrop-blur-md shadow-lg"
           : "bg-transparent"
       )}
     >
       <nav className="max-w-7xl mx-auto px-6 h-20 flex items-center justify-between">
-        {/* Logo - fades in as hero logo fades out */}
+        {/* Logo - on subpages always visible, on homepage fades in on scroll */}
         <motion.a
           href="/"
           className="flex items-center group"
-          style={{ opacity: navLogoOpacity }}
+          style={isHome ? { opacity: navLogoOpacity } : { opacity: 1 }}
         >
           <Logo size={56} className="transition-transform group-hover:scale-105" />
         </motion.a>
@@ -56,7 +66,12 @@ export function Navbar() {
             <a
               key={link.href}
               href={link.href}
-              className="text-white/80 hover:text-amber transition-colors text-sm font-medium tracking-wide uppercase"
+              className={cn(
+                "text-sm font-medium tracking-wide uppercase transition-colors",
+                pathname === link.href
+                  ? "text-amber"
+                  : "text-white/80 hover:text-amber"
+              )}
             >
               {link.label}
             </a>
@@ -66,13 +81,13 @@ export function Navbar() {
         {/* CTA Buttons */}
         <div className="hidden md:flex items-center gap-3">
           <a
-            href="#visit"
+            href="/new"
             className="px-5 py-2.5 text-sm font-semibold text-charcoal bg-amber rounded-full hover:bg-amber-light transition-all hover:shadow-lg hover:shadow-amber/25"
           >
             I&apos;m New
           </a>
           <a
-            href="#give"
+            href="/give"
             className="px-5 py-2.5 text-sm font-semibold text-white border border-white/30 rounded-full hover:bg-white/10 transition-all"
           >
             Give
@@ -104,20 +119,25 @@ export function Navbar() {
                   key={link.href}
                   href={link.href}
                   onClick={() => setMobileOpen(false)}
-                  className="text-white/80 hover:text-amber transition-colors text-base font-medium py-2"
+                  className={cn(
+                    "text-base font-medium py-2 transition-colors",
+                    pathname === link.href
+                      ? "text-amber"
+                      : "text-white/80 hover:text-amber"
+                  )}
                 >
                   {link.label}
                 </a>
               ))}
               <div className="flex flex-col gap-3 pt-4 border-t border-white/10">
                 <a
-                  href="#visit"
+                  href="/new"
                   className="px-5 py-3 text-sm font-semibold text-charcoal bg-amber rounded-full text-center hover:bg-amber-light transition-all"
                 >
                   I&apos;m New
                 </a>
                 <a
-                  href="#give"
+                  href="/give"
                   className="px-5 py-3 text-sm font-semibold text-white border border-white/30 rounded-full text-center hover:bg-white/10 transition-all"
                 >
                   Give

--- a/src/components/PageHero.tsx
+++ b/src/components/PageHero.tsx
@@ -1,0 +1,43 @@
+import { FadeIn } from "./FadeIn";
+import { Breadcrumb } from "./Breadcrumb";
+
+interface PageHeroProps {
+  title: string;
+  subtitle?: string;
+  breadcrumbs?: { label: string; href: string }[];
+}
+
+export function PageHero({ title, subtitle, breadcrumbs }: PageHeroProps) {
+  return (
+    <section
+      className="relative pt-32 pb-16 sm:pt-40 sm:pb-20 overflow-hidden"
+      style={{
+        background:
+          "radial-gradient(ellipse at 50% 50%, rgba(212, 160, 84, 0.15) 0%, transparent 60%), linear-gradient(to bottom, #1A1A1A, #201C16, #1A1A1A)",
+      }}
+    >
+      <div className="relative max-w-4xl mx-auto px-6 text-center">
+        {breadcrumbs && breadcrumbs.length > 0 && (
+          <FadeIn>
+            <Breadcrumb items={breadcrumbs} />
+          </FadeIn>
+        )}
+        <FadeIn delay={0.1}>
+          <h1
+            className="text-4xl sm:text-5xl font-bold text-white mt-4 mb-6"
+            style={{ fontFamily: "var(--font-playfair)" }}
+          >
+            {title}
+          </h1>
+        </FadeIn>
+        {subtitle && (
+          <FadeIn delay={0.2}>
+            <p className="text-white/60 text-lg max-w-xl mx-auto leading-relaxed">
+              {subtitle}
+            </p>
+          </FadeIn>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/SermonBanner.tsx
+++ b/src/components/SermonBanner.tsx
@@ -149,10 +149,12 @@ export function SermonBanner() {
                   <ExternalLink size={16} />
                 </a>
                 <a
-                  href="#subscribe"
+                  href="https://www.youtube.com/@180LifeChurch?sub_confirmation=1"
+                  target="_blank"
+                  rel="noopener noreferrer"
                   className="inline-flex items-center px-6 py-3 text-white border border-white/20 font-semibold rounded-full hover:bg-white/10 transition-all"
                 >
-                  Subscribe to Podcast
+                  Subscribe on YouTube
                 </a>
               </div>
             </FadeIn>

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -146,7 +146,7 @@ export function Services({ services, contact }: ServicesProps) {
               First time? We&apos;d love to meet you.
             </p>
             <a
-              href="#visit-form"
+              href="/new"
               className="inline-flex items-center px-8 py-4 bg-amber text-charcoal font-semibold rounded-full text-lg hover:bg-amber-light transition-all hover:shadow-xl hover:shadow-amber/20 hover:-translate-y-0.5"
             >
               Plan Your First Visit &rarr;

--- a/src/components/StaffCard.tsx
+++ b/src/components/StaffCard.tsx
@@ -1,0 +1,34 @@
+import Image from "next/image";
+import { FadeIn } from "./FadeIn";
+
+interface StaffCardProps {
+  name: string;
+  role: string;
+  image: string;
+  bio?: string;
+  delay?: number;
+}
+
+export function StaffCard({ name, role, image, bio, delay = 0 }: StaffCardProps) {
+  return (
+    <FadeIn delay={delay}>
+      <div className="bg-white rounded-2xl border border-charcoal/8 overflow-hidden group">
+        <div className="relative aspect-[3/4] overflow-hidden">
+          <Image
+            src={image}
+            alt={name}
+            fill
+            className="object-cover transition-transform duration-500 group-hover:scale-105"
+          />
+        </div>
+        <div className="p-6">
+          <h3 className="text-lg font-bold text-charcoal">{name}</h3>
+          <p className="text-amber text-sm font-medium mt-1">{role}</p>
+          {bio && (
+            <p className="text-charcoal/60 text-sm mt-3 leading-relaxed">{bio}</p>
+          )}
+        </div>
+      </div>
+    </FadeIn>
+  );
+}

--- a/src/components/templates/ContentPageTemplate.tsx
+++ b/src/components/templates/ContentPageTemplate.tsx
@@ -1,0 +1,69 @@
+import { Navbar } from "@/components/Navbar";
+import { Footer } from "@/components/Footer";
+import { PageHero } from "@/components/PageHero";
+import { ContentSection } from "@/components/ContentSection";
+import { getFooterProps } from "@/lib/wordpress-fallbacks";
+import type { ContentPageData } from "@/lib/subpage-types";
+
+interface ContentPageTemplateProps {
+  data: ContentPageData;
+}
+
+export function ContentPageTemplate({ data }: ContentPageTemplateProps) {
+  const footerProps = getFooterProps();
+
+  return (
+    <>
+      <Navbar />
+      <PageHero
+        title={data.title}
+        subtitle={data.subtitle}
+        breadcrumbs={data.breadcrumbs}
+      />
+
+      {data.sections.map((section, i) => (
+        <ContentSection
+          key={i}
+          label={section.label}
+          heading={section.heading}
+          headingAccent={section.headingAccent}
+          body={section.body}
+          image={section.image}
+          background={i % 2 === 0 ? "soft-white" : "white"}
+        />
+      ))}
+
+      {data.cta && (
+        <section
+          className="py-16 sm:py-20 text-center"
+          style={{
+            background:
+              "radial-gradient(ellipse at 50% 50%, rgba(212, 160, 84, 0.15) 0%, transparent 60%), linear-gradient(to bottom, #1A1A1A, #201C16, #1A1A1A)",
+          }}
+        >
+          <div className="max-w-3xl mx-auto px-6">
+            <h2
+              className="text-3xl sm:text-4xl font-bold text-white mb-6"
+              style={{ fontFamily: "var(--font-playfair)" }}
+            >
+              {data.cta.heading}
+            </h2>
+            {data.cta.description && (
+              <p className="text-white/60 text-lg mb-8 max-w-xl mx-auto">
+                {data.cta.description}
+              </p>
+            )}
+            <a
+              href={data.cta.link}
+              className="inline-flex items-center gap-2 px-8 py-3.5 bg-amber text-charcoal font-semibold rounded-full hover:bg-amber-light transition-all hover:shadow-lg hover:shadow-amber/25"
+            >
+              {data.cta.text}
+            </a>
+          </div>
+        </section>
+      )}
+
+      <Footer {...footerProps} />
+    </>
+  );
+}

--- a/src/components/templates/MinistryPageTemplate.tsx
+++ b/src/components/templates/MinistryPageTemplate.tsx
@@ -1,0 +1,136 @@
+import { Navbar } from "@/components/Navbar";
+import { Footer } from "@/components/Footer";
+import { PageHero } from "@/components/PageHero";
+import { FadeIn } from "@/components/FadeIn";
+import { StaffCard } from "@/components/StaffCard";
+import { getFooterProps } from "@/lib/wordpress-fallbacks";
+import { Calendar, MapPin, Mail } from "lucide-react";
+import type { MinistryPageData } from "@/lib/subpage-types";
+
+interface MinistryPageTemplateProps {
+  data: MinistryPageData;
+}
+
+export function MinistryPageTemplate({ data }: MinistryPageTemplateProps) {
+  const footerProps = getFooterProps();
+
+  return (
+    <>
+      <Navbar />
+      <PageHero
+        title={data.title}
+        subtitle={data.subtitle}
+        breadcrumbs={[
+          { label: "Ministries", href: "/ministries" },
+          { label: data.title, href: "#" },
+        ]}
+      />
+
+      {/* Description */}
+      <section className="bg-soft-white py-16 sm:py-20">
+        <div className="max-w-3xl mx-auto px-6">
+          {data.description.map((p, i) => (
+            <FadeIn key={i} delay={i * 0.05}>
+              <p className="text-charcoal/70 leading-relaxed mb-4 text-lg">{p}</p>
+            </FadeIn>
+          ))}
+        </div>
+      </section>
+
+      {/* Schedule */}
+      {data.schedule && data.schedule.length > 0 && (
+        <section className="bg-white py-16 sm:py-20">
+          <div className="max-w-3xl mx-auto px-6">
+            <FadeIn>
+              <h2
+                className="text-3xl font-bold text-charcoal mb-8"
+                style={{ fontFamily: "var(--font-playfair)" }}
+              >
+                When We <span className="text-amber">Meet</span>
+              </h2>
+            </FadeIn>
+            <div className="space-y-4">
+              {data.schedule.map((s, i) => (
+                <FadeIn key={i} delay={i * 0.05}>
+                  <div className="flex items-start gap-4 p-5 rounded-xl bg-soft-white border border-charcoal/5">
+                    <div className="w-10 h-10 rounded-lg bg-amber/10 flex items-center justify-center shrink-0">
+                      <Calendar className="text-amber" size={18} />
+                    </div>
+                    <div>
+                      <p className="font-semibold text-charcoal">
+                        {s.day} at {s.time}
+                      </p>
+                      {s.location && (
+                        <p className="text-charcoal/50 text-sm flex items-center gap-1.5 mt-1">
+                          <MapPin size={14} /> {s.location}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                </FadeIn>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Leaders */}
+      {data.leaders && data.leaders.length > 0 && (
+        <section className="bg-soft-white py-16 sm:py-20">
+          <div className="max-w-5xl mx-auto px-6">
+            <FadeIn>
+              <h2
+                className="text-3xl font-bold text-charcoal mb-8 text-center"
+                style={{ fontFamily: "var(--font-playfair)" }}
+              >
+                Meet Our <span className="text-amber">Leaders</span>
+              </h2>
+            </FadeIn>
+            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-8">
+              {data.leaders.map((leader, i) => (
+                <StaffCard
+                  key={leader.name}
+                  name={leader.name}
+                  role={leader.role}
+                  image={leader.image}
+                  delay={i * 0.1}
+                />
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Contact CTA */}
+      {data.contactEmail && (
+        <section className="bg-white py-16 sm:py-20">
+          <div className="max-w-3xl mx-auto px-6 text-center">
+            <FadeIn>
+              <div className="w-14 h-14 rounded-2xl bg-amber/10 flex items-center justify-center mx-auto mb-6">
+                <Mail className="text-amber" size={24} />
+              </div>
+              <h2
+                className="text-3xl font-bold text-charcoal mb-4"
+                style={{ fontFamily: "var(--font-playfair)" }}
+              >
+                Have <span className="text-amber">Questions?</span>
+              </h2>
+              <p className="text-charcoal/60 mb-6">
+                We&apos;d love to hear from you. Reach out and we&apos;ll get back to you soon.
+              </p>
+              <a
+                href={`mailto:${data.contactEmail}`}
+                className="inline-flex items-center gap-2 px-8 py-3.5 bg-amber text-charcoal font-semibold rounded-full hover:bg-amber-light transition-all hover:shadow-lg hover:shadow-amber/25"
+              >
+                Email Us
+                <Mail size={16} />
+              </a>
+            </FadeIn>
+          </div>
+        </section>
+      )}
+
+      <Footer {...footerProps} />
+    </>
+  );
+}

--- a/src/components/templates/SermonSeriesTemplate.tsx
+++ b/src/components/templates/SermonSeriesTemplate.tsx
@@ -1,0 +1,134 @@
+import Image from "next/image";
+import { Navbar } from "@/components/Navbar";
+import { Footer } from "@/components/Footer";
+import { PageHero } from "@/components/PageHero";
+import { FadeIn } from "@/components/FadeIn";
+import { getFooterProps } from "@/lib/wordpress-fallbacks";
+import { Play } from "lucide-react";
+import type { SermonSeriesData } from "@/lib/subpage-types";
+
+interface SermonSeriesTemplateProps {
+  data: SermonSeriesData;
+}
+
+export function SermonSeriesTemplate({ data }: SermonSeriesTemplateProps) {
+  const footerProps = getFooterProps();
+
+  return (
+    <>
+      <Navbar />
+      <PageHero
+        title={data.title}
+        subtitle={data.subtitle}
+        breadcrumbs={[
+          { label: "Sermons", href: "/sermons" },
+          { label: data.title, href: "#" },
+        ]}
+      />
+
+      {/* Description */}
+      {data.description.length > 0 && (
+        <section className="bg-soft-white py-16 sm:py-20">
+          <div className="max-w-3xl mx-auto px-6">
+            {data.description.map((p, i) => (
+              <FadeIn key={i} delay={i * 0.05}>
+                <p className="text-charcoal/70 leading-relaxed mb-4 text-lg">{p}</p>
+              </FadeIn>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Sermons Grid */}
+      <section className="bg-white py-16 sm:py-20">
+        <div className="max-w-6xl mx-auto px-6">
+          <FadeIn>
+            <h2
+              className="text-3xl font-bold text-charcoal mb-10"
+              style={{ fontFamily: "var(--font-playfair)" }}
+            >
+              Messages in This <span className="text-amber">Series</span>
+            </h2>
+          </FadeIn>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {data.sermons.map((sermon, i) => (
+              <FadeIn key={sermon.youtubeId} delay={i * 0.05}>
+                <a
+                  href={`https://www.youtube.com/watch?v=${sermon.youtubeId}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group block rounded-2xl overflow-hidden border border-charcoal/8 hover:shadow-lg transition-shadow"
+                >
+                  <div className="relative aspect-video bg-charcoal/5">
+                    <Image
+                      src={`https://i.ytimg.com/vi/${sermon.youtubeId}/hqdefault.jpg`}
+                      alt={sermon.title}
+                      fill
+                      className="object-cover"
+                    />
+                    <div className="absolute inset-0 bg-black/20 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+                      <div className="w-14 h-14 rounded-full bg-amber flex items-center justify-center">
+                        <Play className="text-charcoal ml-1" size={24} />
+                      </div>
+                    </div>
+                  </div>
+                  <div className="p-5">
+                    <h3 className="font-semibold text-charcoal group-hover:text-amber transition-colors">
+                      {sermon.title}
+                    </h3>
+                    <p className="text-charcoal/50 text-sm mt-1">
+                      {sermon.date}
+                      {sermon.speaker && ` \u00B7 ${sermon.speaker}`}
+                    </p>
+                  </div>
+                </a>
+              </FadeIn>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Related Series */}
+      {data.relatedSeries && data.relatedSeries.length > 0 && (
+        <section className="bg-soft-white py-16 sm:py-20">
+          <div className="max-w-6xl mx-auto px-6">
+            <FadeIn>
+              <h2
+                className="text-3xl font-bold text-charcoal mb-10"
+                style={{ fontFamily: "var(--font-playfair)" }}
+              >
+                More <span className="text-amber">Series</span>
+              </h2>
+            </FadeIn>
+            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+              {data.relatedSeries.map((series, i) => (
+                <FadeIn key={series.slug} delay={i * 0.05}>
+                  <a
+                    href={`/sermons/${series.slug}`}
+                    className="group block rounded-2xl overflow-hidden border border-charcoal/8 bg-white hover:shadow-lg transition-shadow"
+                  >
+                    <div className="relative aspect-video bg-charcoal/5">
+                      <Image
+                        src={series.image}
+                        alt={series.title}
+                        fill
+                        className="object-cover"
+                      />
+                    </div>
+                    <div className="p-5">
+                      <h3 className="font-semibold text-charcoal group-hover:text-amber transition-colors">
+                        {series.title}
+                      </h3>
+                    </div>
+                  </a>
+                </FadeIn>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      <Footer {...footerProps} />
+    </>
+  );
+}

--- a/src/lib/subpage-fallbacks.ts
+++ b/src/lib/subpage-fallbacks.ts
@@ -1,0 +1,539 @@
+// Fallback content for all subpages, sourced from existing 180lifechurch.org
+// Used when WordPress is unreachable, during local dev, or at build time.
+
+import type {
+  MinistryPageData,
+  ContentPageData,
+  SermonSeriesData,
+  LeadershipData,
+} from "./subpage-types";
+
+// ---------------------------------------------------------------------------
+// Ministry Pages
+// ---------------------------------------------------------------------------
+
+export const MINISTRY_PAGES: Record<string, MinistryPageData> = {
+  "life-groups": {
+    title: "180 Life Groups",
+    subtitle:
+      "Life Groups are a great way to get to know others at the church on a more personal level.",
+    slug: "life-groups",
+    description: [
+      "With many people attending on a Sunday morning, it can sometimes be hard to get to know people. 180 Life Groups are a great way to meet others at the church on a more intimate level. This is a place you grow as a disciple of Christ as you study God's Word and fellowship with others.",
+      "Groups typically have around 8 to 15 people and follow along from the Sunday message. Some meet in person, others online, and some are hybrid.",
+      "We offer groups for families, women, men, young adults, and moms of young children.",
+    ],
+    schedule: [
+      { day: "Various Days", time: "Throughout the Week", location: "Various locations around Greater Hartford" },
+    ],
+    contactEmail: "info@180lifechurch.org",
+  },
+  students: {
+    title: "Student Ministry",
+    subtitle:
+      "Student Ministry for grades 6 through 12 in Greater Hartford.",
+    slug: "students",
+    description: [
+      "Our Student Ministry (Grades 6-12) partners with Wintonbury Church and their NextGen Youth Ministry. Our goal is to provide a safe place where students can feel comfortable sharing challenges during their teen years, help prepare them for their future by digging deeper into God's Word, and build relationships with trusted leaders.",
+      "Both Middle School and High School groups meet weekly and separately on two different days of the week. On Sunday mornings, students enjoy live worship in the adult service before connecting with small group leaders for lessons and activities.",
+      "We also have outings, service projects, retreats, and trips throughout the year. We are currently looking for additional leaders. If serving, inspiring, and encouraging the next generation to follow God is something God has put on your heart, please contact Chip to learn how you can be a part of 180 Life Students.",
+    ],
+    schedule: [
+      { day: "Friday", time: "6:30 - 8:30 PM", location: "Middle School" },
+      { day: "Sunday", time: "5:30 - 8:00 PM", location: "High School" },
+      { day: "Sunday", time: "9:00 AM & 11:00 AM", location: "Small groups during service" },
+    ],
+    contactEmail: "chip@180lifechurch.org",
+  },
+  "young-adults": {
+    title: "Young Adults",
+    subtitle:
+      "Are you in your 20s or 30s and looking for community? Join our diverse group of Young Adults in the Greater Hartford area.",
+    slug: "young-adults",
+    description: [
+      "Our young adults are passionate about Jesus and life! We seek to create an authentic place where you can be yourself, make lasting friendships, and encourage one another in the Christian life.",
+      "We hang out together, serve together (in and outside the church), play sports leagues together, and gather every Tuesday evening for worship, teaching, and small groups.",
+      "Ready to learn more about us? Join us for Young Adults Life Group on Tuesdays, or on the first Sunday of the month for lunch right after service! To get connected, reach out to Ben.",
+    ],
+    schedule: [
+      { day: "Tuesday", time: "6:30 PM", location: "180 Life Church" },
+      { day: "First Sunday of the Month", time: "After Service", location: "Lunch together" },
+    ],
+    contactEmail: "ben@180lifechurch.org",
+  },
+  kids: {
+    title: "Kids Ministry",
+    subtitle:
+      "Our mission is to partner with parents and caregivers to help lead their children into a relationship with Jesus and to grow in their faith.",
+    slug: "kids",
+    description: [
+      "Since no one has more potential to influence a child's relationship with God than his or her caretakers, we want to support you as you integrate Biblical truths into your children's everyday lives.",
+      "Our Sunday programming (Nursery through 5th Grade) is offered during both our 9 AM and 11 AM services and is designed specifically to reinforce truths about God in meaningful, developmentally appropriate ways for your child. Middle School (6th through 8th grade) programming is offered during our 11 AM service only.",
+      "Safety is our top priority. We perform a complete background check on anyone who serves with our children and youth. Serving teammates are trained on the policies in place to keep kids safe from check-in to check-out. Each child receives a name tag with a unique alphanumeric code that is changed each week to ensure we can contact families during service and children are returned to their rightful guardians.",
+    ],
+    schedule: [
+      { day: "Sunday", time: "9:00 AM & 11:00 AM", location: "Nursery through 5th Grade" },
+      { day: "Sunday", time: "11:00 AM", location: "Middle School (6th through 8th Grade)" },
+    ],
+    contactEmail: "jennifer@180lifechurch.org",
+  },
+  mens: {
+    title: "Men's Ministry",
+    subtitle:
+      "Equipping men of all ages and walks of life to live on mission as godly men and leaders in their homes, church, community, and world.",
+    slug: "mens",
+    description: [
+      "\"Be on your guard; stand firm in the faith; be courageous; be strong. Do everything in love.\" (1 Corinthians 16:13-14)",
+      "Our church challenges, equips, and encourages men to love God and live lives that reflect His priorities and purposes at home, in our communities, and beyond.",
+      "We have life groups specifically for men here at 180 Life Church. One meets on Monday nights from 7 to 8:30 PM online and the other meets Friday morning from 6 to 7:30 AM at our church building on Still Road in Bloomfield.",
+      "Typical events each year include Men's Breakfast, Iron Sharpens Iron conference in March, a Summer BBQ, and a Fall Retreat.",
+    ],
+    schedule: [
+      { day: "Monday", time: "7:00 - 8:30 PM", location: "Online" },
+      { day: "Friday", time: "6:00 - 7:30 AM", location: "180 Still Road, Bloomfield" },
+    ],
+    contactEmail: "info@180lifechurch.org",
+  },
+  womens: {
+    title: "Women's Ministry",
+    subtitle:
+      "We seek to connect, encourage, and equip women to pursue a deep, transforming relationship with Christ.",
+    slug: "womens",
+    description: [
+      "Through the study of His Word, through authentic relationships with others, and by engaging in ministry, we help women grow deeper in their faith.",
+      "A variety of Life Groups are offered for women to study God's Word together, grow in spiritual maturity, and enjoy fellowship with one another. Groups are ongoing throughout the year.",
+      "\"Pray & Play\" can help moms find what they have been missing: time in prayer, fellowship for themselves and for their kids, hope in God's promises, and support in a safe community of mothers who are leading the next generation for Jesus.",
+      "Every spring and fall the women at 180 Life gather for a retreat. This is a day we intentionally set aside for the Lord with personal prayer time, teaching, and worship. Every September, the ladies head to Camp Berea in New Hampshire for a women's retreat with optional activities like hiking, kayaking, archery, and more.",
+    ],
+    schedule: [
+      { day: "Various Days", time: "Throughout the Week", location: "Life Groups and Events" },
+    ],
+    contactEmail: "women@180lifechurch.org",
+  },
+  missions: {
+    title: "Missions & Outreach",
+    subtitle:
+      "We seek to bring the love of Christ to a community and world in need of the Gospel.",
+    slug: "missions",
+    description: [
+      "At 180 Life we seek to bring the love of Christ to a community in need of the Gospel. We not only support local and worldwide missionaries, but we offer ways for the church body to participate in God's bigger story through mission trips. In the past we have traveled locally here in Connecticut, as well as Miami, West Virginia, and Haiti.",
+      "Whether you participate by yourself, with your family, or with friends, these trips are an opportunity to join in God's work among the nations.",
+    ],
+    contactEmail: "info@180lifechurch.org",
+  },
+  "deaf-ministry": {
+    title: "Deaf Ministry",
+    subtitle:
+      "Sign language interpreted services every Sunday morning.",
+    slug: "deaf-ministry",
+    description: [
+      "\"And let the beauty of the Lord our God be upon us, and establish the work of our hands for us; Yes, establish the work of our hands.\" (Psalms 90:17 NKJV)",
+      "180 Life Church provides a high quality, professional interpreter in American Sign Language every Sunday morning. We believe that every person deserves to experience worship, community, and the love of God in a language and format that is accessible to them.",
+      "For more information on our interpreted services or how you can serve on the team, please contact us by email.",
+    ],
+    schedule: [
+      { day: "Sunday", time: "9:00 AM & 11:00 AM", location: "Main Auditorium, ASL Interpreted" },
+    ],
+    contactEmail: "info@180lifechurch.org",
+  },
+  care: {
+    title: "Care Ministry",
+    subtitle:
+      "We connect people to Christ-centered spiritual, emotional, and relational assistance.",
+    slug: "care",
+    description: [
+      "Depending on your needs, our Care Ministry may minister to you by walking alongside you through a difficult time, helping you develop discipleship relationships, connecting you to other ministries in the church, encouraging you with the truth of Scripture, recommending helpful books, sermons, and online articles, or referring you to a professional Christian counselor.",
+      "Our Pastoral Care team offers hospital visitation and funerals, premarital counseling and weddings, and baby and child dedications.",
+      "Helping Hands is active and provides meals to families welcoming new babies, an illness, or death. Helping Hammers seeks to be the hands and feet of Jesus by using skills and talents to address practical needs within 180 Life Church, like home projects and maintenance.",
+    ],
+    contactEmail: "info@180lifechurch.org",
+  },
+  prayer: {
+    title: "Prayer Ministry",
+    subtitle:
+      "Prayer is a vital part of our relationship with God, as individuals and a church community.",
+    slug: "prayer",
+    description: [
+      "As believers, it is a privilege and responsibility to thank God for all He is doing among us and to intercede for God's wisdom, direction, and provision in the needs of our community, our church, our ministries, and our people.",
+      "We have seen lives changed and transformed through the power of prayer and our team is dedicated to lifting up the needs of the church corporately and individually.",
+      "Join us for Pre-Service Prayer on Sunday mornings from 9:15 to 9:45 AM. All are welcome to attend! Look for the \"Pre-Service Prayer\" banner.",
+      "If you share a similar passion for prayer and are a member, please email us to join our team.",
+    ],
+    schedule: [
+      { day: "Sunday", time: "9:15 - 9:45 AM", location: "Pre-Service Prayer" },
+    ],
+    contactEmail: "info@180lifechurch.org",
+  },
+  serving: {
+    title: "Serving",
+    subtitle:
+      "Discover your role. One of the primary ways of connecting into the life of 180 Life Church is to serve.",
+    slug: "serving",
+    description: [
+      "Our desire is to help believers discover how God has uniquely wired them with gifts, talents, and passions and to equip people to magnify God by serving in their church, community, and the world.",
+      "When you decide to make 180 Life Church your church home, we hope that service will become a part of your life's worship. There are many serving opportunities: setting up on a Sunday morning, greeting and ushering, hospitality, audio-visual, worship, participating in the Kids Ministry, and many more.",
+      "\"God is not unjust; he will not forget your work and the love you have shown him as you have helped his people and continue to help them.\" (Hebrews 6:10, NIV)",
+    ],
+    contactEmail: "info@180lifechurch.org",
+  },
+  "marriage-prep": {
+    title: "Marriage Prep",
+    subtitle:
+      "It is our goal at 180 Life Church to help you prepare for a successful marriage that glorifies God.",
+    slug: "marriage-prep",
+    description: [
+      "Congratulations on your engagement! We are very excited for you! This is a joyous occasion and we are excited to walk with you as you prepare for marriage.",
+      "While the coming months will be very busy with wedding planning and preparations, it is equally important to be preparing your relationship for a healthy and God-honoring marriage.",
+      "Step 1: We will need a few details to help get things started. Let us know a wedding date, location, and to request a pastor to officiate the ceremony.",
+      "Step 2: All couples are required to participate in premarital counseling with a biblical counselor. Premarital counseling should begin 4 to 6 months before the wedding date. There are typically 5 to 6 sessions scheduled every other week, so it will require 3 months to complete the premarital counseling process.",
+    ],
+    contactEmail: "info@180lifechurch.org",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Content Pages
+// ---------------------------------------------------------------------------
+
+export const CONTENT_PAGES: Record<string, ContentPageData> = {
+  about: {
+    title: "About 180 Life Church",
+    subtitle:
+      "We exist to make and send disciples who love and live like Jesus.",
+    breadcrumbs: [{ label: "About", href: "/about" }],
+    sections: [
+      {
+        label: "Our Mission",
+        heading: "Following, Changing,",
+        headingAccent: "Committed",
+        body: [
+          "We exist to make and send disciples who love and live like Jesus. This is the mission of our church and everything that we do is filtered through that lens. Our goal is to live out the great commission and to spread the Good News to the ends of the earth.",
+          "\"And he said to them, 'Follow me, and I will make you fishers of men.'\" (Matthew 4:19)",
+          "180 Life Church members have an intentional relationship with God, His people, and the community. Following Jesus changes us, producing spiritual growth. We are committed to Jesus and actively discipling others.",
+        ],
+        image: { src: "/images/community.jpg", alt: "Church community" },
+      },
+      {
+        label: "Our Story",
+        heading: "How It All",
+        headingAccent: "Started",
+        body: [
+          "180 Life Church is a non-denominational church that started in 2005 when Pastor Bill LaMorey and his wife Rebecca felt called to leave Florida and plant a church in Connecticut. They had a vision to see lives changed by Jesus, and before long, a small group of people started meeting for church at Elmwood Community Center in West Hartford. Through prayer and persistence, the church grew over time, eventually settling into Conard High School for weekly services for 16 years.",
+          "After 18 years of faithful service, God called Pastor Bill and Rebecca back to Florida, and in August 2023 Josh Poteet joined staff as Lead Pastor.",
+          "In June of 2025 we acquired our first building that sits on the Bloomfield/West Hartford line located at 180 Still Road. Services in the new space kicked off in November 2025 and we have fully embraced the blessing that the building is as a tool for ministry.",
+          "Our church is part of the Greater Hartford area, which is full of rich history and diverse communities. It is a place where people from all walks of life can come together, and our church family shares the good news of Jesus with everyone from neighbors to co-workers.",
+        ],
+        image: {
+          src: "/images/ministries/serving.jpg",
+          alt: "Community outreach",
+          position: "left",
+        },
+      },
+      {
+        label: "Sundays",
+        heading: "What to",
+        headingAccent: "Expect",
+        body: [
+          "Our building is located at 180 Still Road in Bloomfield. Doors open at 8:40 AM and church begins at 9 AM for our first service and 11 AM for service two. Please arrive earlier to get yourself settled. If you have children, this ensures ample time to check them into the kids ministry.",
+          "We want you to feel the freedom to come as you are. Some people dress up while others dress casually. Join us in an outfit that you are comfortable in.",
+          "We start with worship, announcements, followed by a message. Each service lasts about 75 minutes.",
+          "If you are new, be sure to head over to the guest center after church where we have a special gift for you and we can answer any of your questions. Do not forget to join us after service for free coffee and refreshments. This is a great way to meet other folks at 180 Life Church.",
+        ],
+      },
+    ],
+    cta: {
+      heading: "Got Questions?",
+      description:
+        "We are here to help with your questions about Jesus, our church, and your own spiritual growth.",
+      text: "Ask Now",
+      link: "/contact",
+    },
+  },
+  partnership: {
+    title: "Partnership",
+    subtitle:
+      "Learn more about who we are as a church and how God uniquely designed you to be a part of the church body.",
+    breadcrumbs: [{ label: "Partnership", href: "/partnership" }],
+    sections: [
+      {
+        label: "Partner With Us",
+        heading: "Your Place in",
+        headingAccent: "the Church Body",
+        body: [
+          "In our two-week Partnership class, we unpack our beliefs, what the Bible says about the church body, and how you fit into the local church. You will have an opportunity to fill out a spiritual gifts assessment test to see how your gifts can be utilized to serve the body.",
+          "Have questions about 180 Life Church or the Bible? This is the perfect class to come, learn, and ask. It is our goal to continue partnering with you on our mission to make and send disciples who love and live like Jesus!",
+        ],
+      },
+    ],
+    cta: {
+      heading: "Ready to Partner?",
+      description:
+        "Be on the lookout for our next class. Contact us for details.",
+      text: "Contact Us",
+      link: "/contact",
+    },
+  },
+  baptism: {
+    title: "Baptism & Dedication",
+    subtitle:
+      "A public declaration of an inward transformation.",
+    breadcrumbs: [{ label: "Baptism", href: "/baptism" }],
+    sections: [
+      {
+        label: "Your Next Step",
+        heading: "What is",
+        headingAccent: "Baptism?",
+        body: [
+          "Baptism is a public declaration of an inward transformation. It is a command from Christ (Matthew 28:19) and an act of obedience. If you are a follower of Jesus and have never been baptized, we encourage you to take this next step in your faith journey!",
+        ],
+      },
+      {
+        heading: "Are You",
+        headingAccent: "Ready?",
+        body: [
+          "If you feel that you are ready to take this next step in your faith journey, sign up for our next baptism! Let us know you are interested or if you have any questions.",
+        ],
+      },
+      {
+        heading: "Child",
+        headingAccent: "Dedication",
+        body: [
+          "Child Dedication is a public commitment parents make before God, the church, and their family. The dedication provides parents an opportunity to express their desire to lead and spiritually nurture their child to know God and encourage them to establish a personal relationship with Jesus Christ.",
+          "Attending a Child Dedication Parent Meeting is a requirement before the Child Dedication Ceremony. If you are interested in dedicating your child on a Sunday morning, please reach out and our Children's Ministry Director will be in touch with you about next steps.",
+        ],
+      },
+    ],
+    cta: {
+      heading: "Interested in Baptism or Dedication?",
+      description:
+        "Congratulations! We would love to celebrate this step with you.",
+      text: "Get in Touch",
+      link: "/contact",
+    },
+  },
+  stories: {
+    title: "Stories",
+    subtitle:
+      "Jesus Changes Everything!",
+    breadcrumbs: [{ label: "Stories", href: "/stories" }],
+    sections: [
+      {
+        label: "Testimonies",
+        heading: "Lives",
+        headingAccent: "Changed",
+        body: [
+          "Take a look at these short videos to see how God is transforming the lives of 180 Life members! Check out our YouTube channel for the full playlist.",
+        ],
+      },
+      {
+        heading: "Share Your",
+        headingAccent: "Story",
+        body: [
+          "Our lives are each unfolding stories that hold incredible power. Whether you are in a great chapter or a challenging chapter, God can use your story to encourage, challenge, and build up those who hear it.",
+          "We believe collecting the stories of our people is a sacred work that can impact not only this generation, but those to come, and we would be honored to hear yours and add it to our library. Your story can be as simple as a few sentences about what God is doing in your life at the moment or your entire journey.",
+        ],
+      },
+    ],
+    cta: {
+      heading: "Have a Story to Share?",
+      description:
+        "We would love to hear how God has been working in your life.",
+      text: "Share Your Story",
+      link: "/contact",
+    },
+  },
+  "new-to-faith": {
+    title: "New to Faith",
+    subtitle:
+      "\"Therefore, if anyone is in Christ, he is a new creation. The old has passed away; behold, the new has come.\" (2 Corinthians 5:17 ESV)",
+    breadcrumbs: [{ label: "New to Faith", href: "/new-to-faith" }],
+    sections: [
+      {
+        label: "We Are Here to Help",
+        heading: "Starting Your",
+        headingAccent: "Journey",
+        body: [
+          "Did you recently give your life to Christ or do you have questions about the Christian faith? We are here to help! We want to send you a Bible, answer your questions, pray for you, and schedule a time to meet up in person if you would like.",
+          "It is God's desire to have a relationship with you and for you to have a strong relationship with other believers. The four areas below can help as you continue along your spiritual journey.",
+        ],
+      },
+      {
+        heading: "Biblical",
+        headingAccent: "Resources",
+        body: [
+          "We would love to send you a physical Bible of your own! This is our gift to you. In the meantime, or if you prefer digital access, check out Bible Gateway (biblegateway.com), Bible Hub (biblehub.com), ESV Online (esv.org), and the YouVersion Bible App.",
+          "To grow in your faith, it is important to maintain a daily time of spending time with God through reading your Bible and prayer. YouVersion Bible App Reading Plans and Our Daily Bread Devotionals are great places to start.",
+        ],
+      },
+      {
+        heading: "Connect",
+        headingAccent: "With Us",
+        body: [
+          "Your friends at 180 Life would love to engage and connect with you! We believe that this life was meant to go through together.",
+          "180 Life Groups are an essential part of 180 Life Church and a great way to get to know people. Groups are typically 10 to 15 people, meeting once a week. There are groups on different days and times of the week.",
+        ],
+      },
+    ],
+    cta: {
+      heading: "What Would You Like to Learn?",
+      description:
+        "How would you like to grow? Reach out to us because we are here for you.",
+      text: "Talk to Someone",
+      link: "/contact",
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Leadership
+// ---------------------------------------------------------------------------
+
+export const LEADERSHIP_DATA: LeadershipData = {
+  pastors: [
+    {
+      name: "Josh Poteet",
+      role: "Lead Pastor",
+      image: "/images/staff/placeholder-male.jpg",
+      bio: "Born in Ohio, Josh grew up in Florida. He and Jennie tied the knot in 2015 and they now have two kids, Lilla and Ezra. Prior to ministry, Josh worked in the Army National Guard Infantry and as an EMT. Since then, he completed his Masters in Theological Studies and has been serving within the local church. Josh is a deep believer in relational discipleship. He personally experienced tremendous life change through discipleship and it is now his passion to create and multiply that culture wherever he goes.",
+    },
+    {
+      name: "Nicholas Leadbeater",
+      role: "Pastor for Ministry Development",
+      image: "/images/staff/placeholder-male.jpg",
+      bio: "While now living in New England, Nicholas is a native of old England. His family is from Birmingham in the center of the UK. After working at a University in London for five years as a Chemistry Professor, he had the opportunity to move to the University of Connecticut. Nicholas and his wife Susan live in Southington. They have been a part of the church since 2006. He was ordained in 2019 and often gets to put his teaching hat on, giving some Sunday morning messages.",
+    },
+  ],
+  staff: [
+    {
+      name: "Chip Anthony",
+      role: "Operations and Student Ministry Director",
+      image: "/images/staff/placeholder-male.jpg",
+      bio: "Born and raised in Connecticut, Chip attended college right down the road from the church in West Hartford. He found the church in January 2006 and felt that it was a place he could truly feel God moving. He joined staff in June 2009. Some of his duties include operations, partnership, life groups, students, and special events. Chip is married to Amanda and they reside in Farmington, CT with their two sons Christian and Thomas.",
+    },
+    {
+      name: "Jennifer Byrne",
+      role: "Children's Ministry Director",
+      image: "/images/staff/placeholder-female.jpg",
+      bio: "Jen joined the team as the Children's Ministry Director in May 2022 but has been attending 180 Life Church since 2008. Originally from a small farm town in Illinois, Jen is passionate about serving the local community, hosting kids and families, and supporting moms and families in this parenting journey. She lives in West Hartford with her husband Jeremy and three daughters Johanna, Julianne, and Jade.",
+    },
+    {
+      name: "Ben Valentine",
+      role: "Director of Worship & Young Adults",
+      image: "/images/staff/placeholder-male.jpg",
+      bio: "Born and raised in the Natural State, Ben recently moved to Connecticut with his wife Grace. He has a passion for leading Christ-centered worship that ushers people into the presence of God, and to see Young Adults emboldened and equipped to be the hands and feet of Jesus making and sending disciples.",
+    },
+    {
+      name: "Emily Oaks",
+      role: "Women's Ministry Director",
+      image: "/images/staff/placeholder-female.jpg",
+      bio: "Emily grew up in Connecticut and is grateful to now call West Hartford home. She first began attending 180 Life Church in 2017. In the fall of 2025, she stepped into the role of Women's Ministry Director. She is passionate about serving the Lord, growing in her own faith, and walking in relationships with others. Outside of church, she is an elementary school teacher in West Hartford.",
+    },
+    {
+      name: "Jim Richert",
+      role: "Men's Ministry Director",
+      image: "/images/staff/placeholder-male.jpg",
+      bio: "Jim is an elder and a lifelong follower of Christ who has been attending 180 Life Church since 2012. Originally from upstate New York, Jim has been married to his best friend Tanya since 2000 and is a dad to three amazing adult children (Caleb, Faith, and Noah). Jim's work focuses on the unique needs of making and sending men as disciples and exhorting them to step up in all areas of their life.",
+    },
+    {
+      name: "Tinisha Noah",
+      role: "Middle School Curriculum Coordinator",
+      image: "/images/staff/placeholder-female.jpg",
+      bio: "Born and raised in Newfoundland, Canada, Tinisha moved to Connecticut in 2017. She resides in Windsor, CT and is married to her husband Blessing Noah. They have three young kids: Grace, Seth, and Trinity. Tinisha joined the Kids Ministry Team in March 2024. She has a passion for Kids and Youth Ministry and a desire to see the next generation know and love God.",
+    },
+    {
+      name: "Ashley Perri",
+      role: "Kids Curriculum Specialist",
+      image: "/images/staff/placeholder-female.jpg",
+      bio: "Ashley is our Kids Curriculum Specialist for ages birth through 5th grade. She received her bachelor's degree in middle school math and science education from Valparaiso University in 2009. She and her husband Ryan are both originally from the Chicago area but have called Farmington home since 2020. They have 3 boys: Jackson, Wyatt, and Miles.",
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Elders
+// ---------------------------------------------------------------------------
+
+export const ELDERS = [
+  { name: "Jeff Doot", role: "Secretary" },
+  { name: "Sam Kim", role: "Elder" },
+  { name: "Jim Richert", role: "Chair" },
+  { name: "Jose Rios", role: "Treasurer" },
+];
+
+export const ELDERS_DESCRIPTION =
+  "The Elders provide intentional shepherding within the church body and offer accountability and counsel to the Lead Pastor regarding major financial and strategic decisions. Their role is to facilitate alignment toward our mission of making disciples.";
+
+export const ELDERS_EMAIL = "elders@180lifechurch.org";
+
+// ---------------------------------------------------------------------------
+// Sermon Series (placeholder, actual sermons on Church Center)
+// ---------------------------------------------------------------------------
+
+export const SERMON_SERIES: Record<string, SermonSeriesData> = {
+  "at-the-movies": {
+    title: "At the Movies",
+    subtitle: "Exploring biblical truths through the lens of movies.",
+    slug: "at-the-movies",
+    image: "/images/series/placeholder.jpg",
+    description: [
+      "We will watch select scenes from movies on select Sunday mornings during church and explore the biblical truths they reveal. Join us for this creative and engaging series!",
+    ],
+    sermons: [
+      {
+        title: "At the Movies: Week 1",
+        date: "February 2024",
+        youtubeId: "dQw4w9WgXcQ",
+        speaker: "Pastor Josh Poteet",
+      },
+      {
+        title: "At the Movies: Week 2",
+        date: "February 2024",
+        youtubeId: "dQw4w9WgXcQ",
+        speaker: "Pastor Josh Poteet",
+      },
+    ],
+  },
+  "say-yes": {
+    title: "Say Yes",
+    subtitle: "What happens when you say yes to God?",
+    slug: "say-yes",
+    image: "/images/series/placeholder.jpg",
+    description: [
+      "When God asks you to take a step of faith, what happens when you say yes? This series explores the stories of people in the Bible who said yes to God and the incredible things that followed.",
+    ],
+    sermons: [
+      {
+        title: "Say Yes: Week 1",
+        date: "November 2023",
+        youtubeId: "dQw4w9WgXcQ",
+        speaker: "Pastor Josh Poteet",
+      },
+      {
+        title: "Say Yes: Week 2",
+        date: "November 2023",
+        youtubeId: "dQw4w9WgXcQ",
+        speaker: "Pastor Josh Poteet",
+      },
+    ],
+  },
+  "as-it-is-in-heaven": {
+    title: "As It Is in Heaven",
+    subtitle: "A Christmas offering and celebration of God's generosity.",
+    slug: "as-it-is-in-heaven",
+    image: "/images/series/placeholder.jpg",
+    description: [
+      "Thank you for partnering with 180 Life Church! During this Christmas season, we invite you to consider contributing to our special offering that benefits three key areas of ministry.",
+    ],
+    sermons: [
+      {
+        title: "As It Is in Heaven: Christmas Message",
+        date: "December 2024",
+        youtubeId: "dQw4w9WgXcQ",
+        speaker: "Pastor Josh Poteet",
+      },
+    ],
+  },
+};
+
+/** All series slugs for static generation */
+export const ALL_SERIES_SLUGS = Object.keys(SERMON_SERIES);

--- a/src/lib/subpage-types.ts
+++ b/src/lib/subpage-types.ts
@@ -1,0 +1,47 @@
+// Types for subpage content — ministry pages, content pages, sermon series, leadership
+
+export interface MinistryPageData {
+  title: string;
+  subtitle: string;
+  slug: string;
+  description: string[];
+  schedule?: { day: string; time: string; location?: string }[];
+  leaders?: { name: string; role: string; image: string }[];
+  contactEmail?: string;
+}
+
+export interface ContentPageData {
+  title: string;
+  subtitle?: string;
+  breadcrumbs?: { label: string; href: string }[];
+  sections: {
+    label?: string;
+    heading: string;
+    headingAccent?: string;
+    body: string | string[];
+    image?: { src: string; alt: string; position?: "left" | "right" };
+  }[];
+  cta?: { heading: string; description?: string; text: string; link: string };
+}
+
+export interface SermonSeriesData {
+  title: string;
+  subtitle: string;
+  slug: string;
+  description: string[];
+  image: string;
+  sermons: { title: string; date: string; youtubeId: string; speaker?: string }[];
+  relatedSeries?: { title: string; slug: string; image: string }[];
+}
+
+export interface StaffMember {
+  name: string;
+  role: string;
+  image: string;
+  bio?: string;
+}
+
+export interface LeadershipData {
+  pastors: StaffMember[];
+  staff: StaffMember[];
+}

--- a/src/lib/wordpress-fallbacks.ts
+++ b/src/lib/wordpress-fallbacks.ts
@@ -125,6 +125,15 @@ export const FALLBACK_SERVICES: WPService[] = [
   },
 ];
 
+/** Convenience helper so every subpage doesn't repeat Footer prop wiring */
+export function getFooterProps() {
+  return {
+    contact: FALLBACK_SETTINGS.contact,
+    missionStatement: FALLBACK_SETTINGS.missionStatement,
+    churchTagline: FALLBACK_SETTINGS.churchTagline,
+  };
+}
+
 export const FALLBACK_SETTINGS: WPSiteSettings = {
   hero: {
     tagline: "No Perfect People Allowed",
@@ -157,7 +166,7 @@ export const FALLBACK_SETTINGS: WPSiteSettings = {
     ],
     image: "/images/community.jpg",
     linkText: "Learn More About Us",
-    linkUrl: "#about-more",
+    linkUrl: "/about",
   },
   contact: {
     addressLine1: "180 Still Road",
@@ -178,9 +187,9 @@ export const FALLBACK_SETTINGS: WPSiteSettings = {
     headingAccent: "Starts Here",
     body: "It doesn't matter where you've been or what your story looks like. There's a seat saved for you. Come as you are.",
     primaryText: "I'm New Here",
-    primaryLink: "#visit-form",
+    primaryLink: "/new",
     secondaryText: "Contact Us",
-    secondaryLink: "#contact",
+    secondaryLink: "/contact",
   },
   missionStatement:
     "We exist to make and send disciples who love and live like Jesus.",

--- a/src/lib/wordpress.ts
+++ b/src/lib/wordpress.ts
@@ -218,7 +218,7 @@ function parseAboutData(acf: Record<string, unknown>): WPAboutData {
     body,
     image: extractImageUrl(acf.about_image) || "/images/community.jpg",
     linkText: (acf.about_link_text as string) || "Learn More About Us",
-    linkUrl: (acf.about_link_url as string) || "#about-more",
+    linkUrl: (acf.about_link_url as string) || "/about",
   };
 }
 
@@ -260,9 +260,9 @@ function parseCTAData(acf: Record<string, unknown>): WPCTAData {
       (acf.cta_body as string) ||
       "It doesn't matter where you've been or what your story looks like. There's a seat saved for you. Come as you are.",
     primaryText: (acf.cta_primary_text as string) || "I'm New Here",
-    primaryLink: (acf.cta_primary_link as string) || "#visit-form",
+    primaryLink: (acf.cta_primary_link as string) || "/new",
     secondaryText: (acf.cta_secondary_text as string) || "Contact Us",
-    secondaryLink: (acf.cta_secondary_link as string) || "#contact",
+    secondaryLink: (acf.cta_secondary_link as string) || "/contact",
   };
 }
 


### PR DESCRIPTION
## Summary

- **35+ new pages** replicating the full 180lifechurch.org sitemap with real content (no em-dashes per brand guidelines)
- **Redesigned ministries hub** with 3 grouped sections (Age/Stage, Grow Together, Serve/Care), featured hero cards with photos, and schedule info on every card
- **6 shared components**: PageHero, Breadcrumb, ContentSection, StaffCard, ContactForm (Formspree), plus 3 reusable page templates
- **12 ministry subpages** with real content from the live site, including new marriage-prep page
- **Core pages**: about, contact, give (tithe/text-to-give/FPU), leadership (pastors + staff + elders), partnership, baptism, new (plan a visit), new-to-faith, stories, sermons hub + 3 series, privacy, terms
- **Navbar fixes**: route-aware logo visibility, active link highlighting, mobile menu auto-close
- **Card upgrades** across all subpages: gradient backgrounds, watermark icons, hover animations, consistent heights
- **Back button bug fix**: resolves invisible content after browser back/forward navigation

## Routes

41 total routes, zero build errors. Key additions:
- `/about`, `/contact`, `/give`, `/leadership`, `/new`, `/new-to-faith`
- `/ministries` (hub) + 12 ministry subpages
- `/sermons` (hub) + 3 dynamic series pages
- `/partnership`, `/baptism`, `/stories`, `/serving`
- `/membership` redirects to `/partnership`

---

## Root Cause Analysis: Back Button Navigation Bug

### Symptom
After navigating from the homepage to any subpage and pressing the browser back button, all page content became invisible. The hero background image was faintly visible but the logo, headings, text, and CTA buttons were completely gone.

### Root Cause
A conflict between **Framer Motion's animation lifecycle** and **Next.js App Router's client-side cache**.

**How animations normally work:**
1. Framer Motion elements render with `initial={{ opacity: 0, y: 30 }}`
2. On mount, `animate={{ opacity: 1, y: 0 }}` fires and transitions the element in
3. For `whileInView` elements, `viewport={{ once: true }}` means the animation fires once when scrolled into view and never again

**What happens on back navigation:**
1. User visits homepage (animations play, elements reach `opacity: 1`)
2. User clicks a nav link (Next.js does client-side navigation to new page)
3. User presses Back button
4. Next.js App Router fires a `popstate` event and **restores the homepage from its client-side React cache**
5. The cached React tree is **NOT remounted** -- components keep their existing state
6. Framer Motion's `animate` prop has already fired (marked complete) and `once: true` has already triggered
7. Since no remount occurs, `initial` values are re-applied but `animate` never replays
8. All content is stuck at `opacity: 0` with offset transforms

### Attempted Fixes (and why they failed)

| Approach | Why it failed |
|----------|--------------|
| **Per-component `isBfcache` state** (useState + pageshow event in Hero/FadeIn) | State change happens AFTER initial render, so Framer Motion already applied `opacity: 0` inline styles before the re-render could override them |
| **Inline `<script>` with dangerouslySetInnerHTML** | Caused infinite "Router action dispatched before initialization" loop -- the reload triggered before Next.js router initialized |
| **`RouteChangeRemount` wrapper with `key={pathname}`** | Next.js App Router manages the children slot specially; the key change didn't force a remount of the cached tree |
| **`usePathname()` in layout useEffect** | The layout component doesn't re-render on popstate in App Router; the hook doesn't trigger reliably during back navigation |
| **URL polling (setInterval every 200ms)** | Worked for back navigation BUT also fired on forward link clicks, killing entrance animations on new pages (jittery transitions) |

### Final Fix: `BfcacheReloader` component (`src/components/BfcacheReloader.tsx`)

Two-pronged approach in a single client component mounted in the root layout:

**1. True bfcache restore** (browser freezes/thaws the entire page):
- Listen for `pageshow` event with `e.persisted === true`
- Force a full `window.location.reload()` to reset all state

**2. SPA back/forward navigation** (Next.js cache restore):
- Listen for `popstate` event (only fires on browser back/forward, NOT on link clicks)
- After 300ms delay (lets Next.js finish rendering the cached page), scan the DOM for elements with inline `opacity: 0`
- Smoothly transition them to `opacity: 1` with a 0.4s ease-out

**Key design decisions:**
- **`popstate` not polling**: Only triggers on back/forward, so forward navigation entrance animations are completely untouched
- **Only fixes opacity, not transforms**: Avoids disrupting scroll-driven motion values (like the hero logo parallax) and element positioning
- **`setTimeout` not `requestAnimationFrame`**: rAF is throttled/paused in background tabs; setTimeout is reliable regardless of tab visibility
- **300ms delay**: Gives Next.js App Router enough time to swap in the cached React tree and settle before the DOM scan

### Verification
Programmatic test confirmed: 47 stuck elements fixed to visible after simulated back navigation, while forward navigation preserved all `opacity: 0` initial states for smooth entrance animations.

---

## Test plan

- [x] `npm run build` passes with 41 routes, zero errors
- [x] All navbar links navigate correctly (About, Leadership, Ministries, Sermons, Contact)
- [x] Back button from subpage to homepage renders correctly (logo, hero, transparent nav)
- [x] Ministries hub shows 3 grouped sections with hero cards and schedule info
- [x] Give page shows tithe explanation, text-to-give (84321), FPU, non-cash giving
- [x] Leadership page shows pastors, staff bios, and elders section
- [x] /membership redirects to /partnership
- [x] Mobile responsive on all pages (375px, 768px, 1280px)
- [x] Contact form submits to Formspree

🤖 Generated with [Claude Code](https://claude.com/claude-code)