### PR TITLE
Stage 3: External links, WP compatibility, and editorial docs

### DIFF
--- a/docs/wordpress-editorial-guide.md
+++ b/docs/wordpress-editorial-guide.md
@@ -1,0 +1,373 @@
+# 180 Life Church Website - Editorial Guide
+
+> A plain-English guide for updating website content through WordPress.
+> No coding required. If you can use Facebook or Google Docs, you can do this.
+
+---
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+- [Updating Staff and Leadership](#updating-staff-and-leadership)
+- [Updating Ministry Pages](#updating-ministry-pages)
+- [Adding or Editing Events](#adding-or-editing-events)
+- [Updating Service Times](#updating-service-times)
+- [Managing Sermon Series](#managing-sermon-series)
+- [Updating the Homepage](#updating-the-homepage)
+- [Editing Other Pages](#editing-other-pages)
+- [Working with Images](#working-with-images)
+- [How Changes Go Live](#how-changes-go-live)
+- [Common Tasks Cheat Sheet](#common-tasks-cheat-sheet)
+- [FAQ](#faq)
+
+---
+
+## Getting Started
+
+### Logging In
+
+1. Go to **https://180lifechurch.org/wp-admin** in your browser
+2. Enter your username and password
+3. You will land on the WordPress Dashboard
+
+### Finding Your Way Around
+
+The left sidebar is your main menu. The items you will use most often:
+
+| Sidebar Item | What It Controls |
+|-------------|-----------------|
+| **Staff** | Pastor and team member bios and photos |
+| **Elders** | Elder names, roles, and photos |
+| **Events** | Upcoming events shown on the homepage |
+| **Ministries** | The 6 ministry cards on the homepage |
+| **Ministry Pages** | The detailed pages for each ministry (Kids, Life Groups, etc.) |
+| **Content Pages** | About, Partnership, Baptism, Stories, and New to Faith pages |
+| **Services** | Sunday service times |
+| **Sermon Series** | Sermon series with YouTube video links |
+| **Site Settings** | Homepage hero banner, church contact info, social media links |
+
+---
+
+## Updating Staff and Leadership
+
+### Adding a New Staff Member
+
+1. In the left sidebar, click **Staff**
+2. Click the **Add New** button at the top
+3. In the **Title** field, type the person's full name (e.g. "Josh Poteet")
+4. Scroll down to the custom fields section:
+   - **Role:** Type their title (e.g. "Lead Pastor" or "Children's Ministry Director")
+   - **Photo:** Click "Add Image" and upload their headshot
+   - **Bio:** Write a short paragraph about them
+5. Click the blue **Publish** button in the top right
+
+> **Tip:** If someone's role includes the word "Pastor", they will automatically
+> appear in the **Pastors** section at the top of the leadership page. Everyone
+> else appears in the **Team** section below.
+
+### Editing an Existing Staff Member
+
+1. Click **Staff** in the sidebar
+2. Find the person's name in the list and click on it
+3. Make your changes
+4. Click **Update**
+
+### Removing a Staff Member
+
+1. Click **Staff** in the sidebar
+2. Hover over the person's name
+3. Click **Trash**
+
+### Updating Elders
+
+Same process as Staff, but click **Elders** in the sidebar instead. Elder fields are:
+
+- **Title:** The elder's name
+- **Role:** Their position (Chair, Secretary, Treasurer, or Elder)
+- **Photo:** Optional headshot
+
+---
+
+## Updating Ministry Pages
+
+There are two different places for ministry content. Here is when to use each:
+
+### Homepage Ministry Cards (the 6 cards visitors see first)
+
+These are short previews that appear on the homepage.
+
+1. Click **Ministries** in the sidebar
+2. Click on the ministry you want to edit
+3. You can change:
+   - **Description:** The short blurb on the card
+   - **Image:** The card background photo
+   - **Tag:** The label in the corner (e.g. "Sundays", "Weekly")
+   - **Sort Order:** A number that controls the display order (lower numbers appear first)
+4. Click **Update**
+
+### Detailed Ministry Pages (the full page when someone clicks "Learn More")
+
+These are the in-depth pages with schedules, descriptions, and links.
+
+1. Click **Ministry Pages** in the sidebar
+2. Click on the ministry you want to edit (e.g. "Kids Ministry", "Life Groups")
+3. You can change:
+   - **Subtitle:** The text shown below the title at the top of the page
+   - **Description:** The main body text. You can use bold, italic, and links just like in a Word document
+   - **Schedule:** Click "Add Row" to add meeting times. Each row has:
+     - Day (e.g. "Sunday")
+     - Time (e.g. "9:00 AM & 11:00 AM")
+     - Location (e.g. "Main Auditorium") - optional
+   - **Contact Email:** The email address shown in the "Have Questions?" section
+   - **External Links:** Links to Church Center, Google Drive, YouTube, etc. Each row has:
+     - Label (e.g. "Find a Life Group")
+     - URL (paste the full link)
+     - Description (e.g. "Browse and join a group on Church Center") - optional
+4. Click **Update**
+
+> **Important:** Do not change the "slug" (the URL-friendly name) of ministry pages.
+> If you rename "life-groups" to "small-groups", the website link will break.
+> If you need to rename a ministry, contact your web administrator.
+
+---
+
+## Adding or Editing Events
+
+### Adding a New Event
+
+1. Click **Events** in the sidebar
+2. Click **Add New**
+3. In the **Title** field, type the event name (e.g. "Easter at 180 Life")
+4. Fill in the fields:
+   - **Date:** Type the date as you want it displayed (e.g. "April 20" or "Every Tuesday")
+   - **Time:** Type the time (e.g. "9:00 AM & 11:00 AM")
+   - **Description:** A short description (1-2 sentences) for the event card
+   - **Featured:** Check this box to make the event stand out with a dark card
+   - **Link:** Paste a Church Center registration link if the event has online signup
+5. Click **Publish**
+
+### Removing an Old Event
+
+1. Click **Events** in the sidebar
+2. Hover over the event name
+3. Click **Trash**
+
+> **Tip:** Keep only 3-4 events visible at a time. Too many events on the homepage
+> can feel overwhelming to visitors.
+
+---
+
+## Updating Service Times
+
+1. Click **Services** in the sidebar
+2. Click on the service you want to edit (e.g. "First Service")
+3. You can change:
+   - **Day:** e.g. "Sunday"
+   - **Time:** e.g. "9:00 AM"
+   - **Description:** A short note about the service
+   - **Sort Order:** Controls the display order
+4. Click **Update**
+
+### Adding a New Service (e.g. a special holiday service)
+
+1. Click **Services** > **Add New**
+2. Give it a title (e.g. "Christmas Eve Service")
+3. Fill in the fields and click **Publish**
+
+---
+
+## Managing Sermon Series
+
+### Adding a New Sermon Series
+
+1. Click **Sermon Series** in the sidebar
+2. Click **Add New**
+3. In the **Title** field, type the series name (e.g. "At the Movies")
+4. Fill in:
+   - **Slug:** A URL-friendly version of the name using lowercase letters and hyphens (e.g. "at-the-movies"). This becomes part of the web address.
+   - **Subtitle:** A short tagline
+   - **Description:** A paragraph about the series
+   - **Image:** Upload a series cover image or thumbnail
+5. To add sermons to the series, scroll to the **Sermons** section and click **Add Row** for each sermon:
+   - **Title:** The sermon title (e.g. "At the Movies: Week 1")
+   - **Date:** Display date (e.g. "February 2024")
+   - **YouTube ID:** The video code from YouTube. To find this:
+     1. Go to the sermon video on YouTube
+     2. Look at the URL: `https://www.youtube.com/watch?v=ABC123xyz`
+     3. The ID is the part after `v=` -- in this example, `ABC123xyz`
+   - **Speaker:** The speaker's name (optional)
+6. Click **Publish**
+
+### Finding a YouTube Video ID
+
+Here is a visual breakdown:
+
+```
+Full URL:  https://www.youtube.com/watch?v=dQw4w9WgXcQ
+                                           ^^^^^^^^^^^
+                                           This part is the ID
+
+Short URL: https://youtu.be/dQw4w9WgXcQ
+                            ^^^^^^^^^^^
+                            This part is the ID
+```
+
+Just copy the characters after `v=` (or after `youtu.be/`) and paste it into the YouTube ID field.
+
+---
+
+## Updating the Homepage
+
+The homepage pulls content from several places. Here is where to find each section:
+
+### Hero Banner (the big image and text at the top)
+
+1. Click **Site Settings** in the sidebar (or go to the Settings/Options page if using ACF Pro)
+2. Look for the **Hero Section** fields:
+   - **Tagline:** The small text above the heading (e.g. "No Perfect People Allowed")
+   - **Heading Prefix:** The main heading (e.g. "Jesus Changes")
+   - **Rotating Words:** The words that cycle through in amber. Click "Add Row" for each word
+   - **Description:** The paragraph below the heading
+   - **Image:** The background photo
+   - **Primary Button:** Text and link for the gold button (e.g. "Plan Your Visit" linking to "/new")
+   - **Secondary Button:** Text and link for the outline button (e.g. "Watch Online" linking to the livestream)
+3. Click **Update**
+
+### "A Place Where You Belong" Section
+
+Same **Site Settings** page, scroll to the **About Section**:
+- **Label, Heading, Heading Accent:** Control the section title
+- **Body:** The two paragraphs of text
+- **Image:** The community photo
+- **Link Text/URL:** The "Learn More About Us" link
+
+### Church Contact Info (footer and contact page)
+
+Same **Site Settings** page, scroll to the **Contact Info** section:
+- Address, phone, email, service times
+
+### Social Media Links
+
+Same **Site Settings** page, scroll to **Social Media**:
+- Facebook, Instagram, YouTube, Vimeo URLs
+
+### Mission Statement and Tagline
+
+Same **Site Settings** page, at the bottom:
+- **Mission Statement:** Appears in the footer
+- **Church Tagline:** Appears in the footer in italic
+
+---
+
+## Editing Other Pages
+
+### About, Partnership, Baptism, Stories, and New to Faith
+
+1. Click **Content Pages** in the sidebar
+2. Click on the page you want to edit
+3. You can change:
+   - **Subtitle:** Text shown at the top of the page below the title
+   - **Sections:** Each section has its own heading, optional label, body text, and optional image. Click "Add Row" to add a new section or use the arrows to reorder them
+   - **Call-to-Action:** The banner at the bottom with a heading, description, button text, and button link
+4. Click **Update**
+
+> **Tip:** For the CTA button link, you can use:
+> - An internal page like `/contact` (just the path, starting with `/`)
+> - An external link like `https://180life.churchcenter.com/giving` (full URL)
+> External links will automatically open in a new tab for visitors.
+
+---
+
+## Working with Images
+
+### Recommended Image Sizes
+
+| Where | Recommended Size | Format |
+|-------|-----------------|--------|
+| Staff/Elder headshot | 600 x 800 px (portrait) | JPG or PNG |
+| Hero background | 1920 x 1080 px (landscape) | JPG |
+| Ministry card | 800 x 600 px (landscape) | JPG |
+| Sermon series cover | 1280 x 720 px (16:9) | JPG or PNG |
+| About/community photo | 800 x 600 px | JPG |
+
+### Uploading Images
+
+1. When you see an Image field, click **Add Image** (or **Select Image**)
+2. You can either:
+   - **Upload:** Drag a file from your computer, or click "Select Files"
+   - **Media Library:** Choose a photo you have already uploaded
+3. Click **Select** to confirm
+
+### Image Tips
+
+- **Headshots** look best when the person is centered and the photo is cropped from roughly chest-level up
+- **Compress large images** before uploading. Use a free tool like [TinyPNG](https://tinypng.com) to reduce file size without losing quality
+- **Use JPG** for photographs and **PNG** for logos or graphics with transparent backgrounds
+- **Avoid images with text baked in** as they cannot be read by screen readers or search engines
+
+---
+
+## How Changes Go Live
+
+When you click **Publish** or **Update** in WordPress:
+
+1. WordPress saves your changes immediately
+2. Within a few seconds, a signal is sent to the website
+3. The website clears its cached version of that page
+4. The next visitor to that page sees the updated content
+
+**You do not need to do anything else.** There is no separate "deploy" or "push live" step.
+
+> **Note:** It may take up to 60 seconds for changes to appear. If you do not see
+> your changes right away, try refreshing the page (Ctrl+R or Cmd+R). If changes
+> still do not appear after a few minutes, contact your web administrator.
+
+---
+
+## Common Tasks Cheat Sheet
+
+| I want to... | Go to... | Then... |
+|-------------|---------|---------|
+| Add a new staff member | Staff > Add New | Fill in name, role, photo, bio > Publish |
+| Update someone's bio | Staff > click their name | Edit the Bio field > Update |
+| Remove a staff member | Staff > hover name > Trash | |
+| Change service times | Services > click the service | Edit time/day > Update |
+| Add an upcoming event | Events > Add New | Fill in details > Publish |
+| Remove a past event | Events > hover name > Trash | |
+| Update a ministry page | Ministry Pages > click it | Edit fields > Update |
+| Add a Church Center link to a ministry | Ministry Pages > External Links > Add Row | Fill in label and URL > Update |
+| Change the homepage banner text | Site Settings > Hero Section | Edit fields > Update |
+| Update the church phone number | Site Settings > Contact Info | Edit phone > Update |
+| Add a new sermon series | Sermon Series > Add New | Fill in details + YouTube IDs > Publish |
+| Change a social media link | Site Settings > Social Media | Edit URL > Update |
+
+---
+
+## FAQ
+
+**Q: I made a change but the website still shows the old content.**
+A: Wait 60 seconds and refresh the page. If it still has not changed, try opening the page in a private/incognito browser window. Your browser may be showing a cached version.
+
+**Q: Can I preview my changes before publishing?**
+A: Yes. When editing, click **Preview** (or **Save Draft** first, then **Preview**) to see how your changes will look. The preview is only visible to you.
+
+**Q: I accidentally deleted something. Can I get it back?**
+A: Yes. In the sidebar, click on the content type (e.g. Staff), then click the **Trash** link above the list. Find the item and click **Restore**.
+
+**Q: Can I schedule a change to go live in the future?**
+A: Yes. Instead of clicking Publish, click the **Edit** link next to "Publish immediately" and set a future date and time. WordPress will publish it automatically at that time.
+
+**Q: How do I reorder the ministries on the homepage?**
+A: Go to Ministries, open each one, and change the **Sort Order** number. Lower numbers appear first (1, 2, 3...).
+
+**Q: What if I need to add a completely new page to the website?**
+A: Adding a new route to the website requires a code change. Contact your web administrator. However, you can add new entries to existing sections (new staff, new events, new sermon series, new ministry pages) without any code changes.
+
+**Q: Who do I contact if something is broken?**
+A: Reach out to your web administrator. If the website itself is down, check [Vercel Status](https://www.vercel-status.com) to see if there is a platform-wide issue.
+
+**Q: I do not see "Staff" or "Ministry Pages" in my sidebar.**
+A: Your WordPress account may not have the right permissions. Ask an admin to ensure your role is set to **Editor** or **Administrator**.
+
+**Q: What are "slugs" and why should I not change them?**
+A: A slug is the URL-friendly name that appears in the web address. For example, the Kids Ministry page lives at `180lifechurch.com/ministries/kids`. The slug is `kids`. If you change it to something else, the old link will break and visitors will see a "Page Not Found" error. If you need to rename something, contact your web administrator so they can update the website code to match.

--- a/docs/wordpress-setup-guide.md
+++ b/docs/wordpress-setup-guide.md
@@ -1,0 +1,505 @@
+# WordPress Headless CMS Setup Guide
+
+> This document describes everything needed to connect the 180 Life Church Next.js
+> site to WordPress as a headless CMS. Until WordPress is configured, the site
+> renders using hardcoded fallback content with zero visual difference.
+
+---
+
+## Table of Contents
+
+1. [Architecture Overview](#architecture-overview)
+2. [Environment Variables](#environment-variables)
+3. [Required WordPress Plugins](#required-wordpress-plugins)
+4. [Custom Post Types](#custom-post-types)
+5. [ACF Field Groups](#acf-field-groups)
+6. [Webhook Configuration](#webhook-configuration)
+7. [Vercel Deployment Settings](#vercel-deployment-settings)
+8. [Testing the Integration](#testing-the-integration)
+9. [Troubleshooting](#troubleshooting)
+
+---
+
+## Architecture Overview
+
+```
+WordPress (CMS)          Next.js (Vercel)           User
++-----------------+      +--------------------+
+| WP REST API     | ---> | data.ts            | ---> Browser
+| /wp-json/wp/v2/ |      |   fetchEvents()    |
+| /wp-json/acf/v3/|      |   fetchLeadership()|
++-----------------+      |   fetchMinistry()  |
+        |                |   ...              |
+        |                +--------------------+
+        |                         |
+        |  on publish:            | on miss:
+        |  POST /api/revalidate   | use fallback
+        +-------------------------+ content
+```
+
+**Data flow:**
+
+1. Every page calls a `fetchX()` function from `src/lib/data.ts`
+2. `data.ts` calls the corresponding WP fetch function from `src/lib/wordpress.ts`
+3. If `WORDPRESS_URL` is not set or the fetch fails, fallback data is returned
+4. ISR caches responses for 1 hour; on-demand revalidation clears the cache instantly
+5. Fallback content lives in `src/lib/wordpress-fallbacks.ts` (homepage) and `src/lib/subpage-fallbacks.ts` (subpages)
+
+---
+
+## Environment Variables
+
+Set these in Vercel project settings (Settings > Environment Variables) and in `.env.local` for local dev:
+
+| Variable | Required | Example | Description |
+|----------|----------|---------|-------------|
+| `WORDPRESS_URL` | Yes | `https://180lifechurch.org` | Base URL of the WordPress site (no trailing slash) |
+| `WORDPRESS_REVALIDATION_SECRET` | Yes | `a-long-random-string-here` | Shared secret for the webhook. Generate with `openssl rand -hex 32` |
+
+**Without these variables set, the site operates entirely on fallback content.**
+
+---
+
+## Required WordPress Plugins
+
+| Plugin | Purpose | Free/Pro |
+|--------|---------|----------|
+| **Advanced Custom Fields (ACF)** | Custom field groups for all content | Free works; Pro recommended for repeaters and options pages |
+| **ACF to REST API** | Exposes ACF fields via `/wp-json/acf/v3/` | Free (only needed if using ACF Pro options page for site settings) |
+| **Custom Post Type UI (CPT UI)** | Register custom post types without code | Free |
+| **WP Webhooks** (or custom `save_post` hook) | Fires a POST to Vercel on content publish | Free tier available |
+
+### Alternative to plugins
+
+All CPTs and ACF field groups can be registered via code in a custom theme's `functions.php` or a site-specific plugin. See the [CPT and ACF Field Reference](#custom-post-types) below for exact slugs and field names.
+
+---
+
+## Custom Post Types
+
+Register each CPT with `show_in_rest = true` so the REST API exposes them.
+
+| CPT Slug | Label | REST Base | Description |
+|----------|-------|-----------|-------------|
+| `event` | Events | `event` | Church events (Easter, retreats, etc.) |
+| `ministry` | Ministries | `ministry` | Homepage ministry cards (6 featured) |
+| `service` | Services | `service` | Sunday service times |
+| `staff` | Staff | `staff` | Pastors and team members |
+| `elder` | Elders | `elder` | Elder board members |
+| `ministry-page` | Ministry Pages | `ministry-page` | Detailed content for each ministry subpage (12 total) |
+| `content-page` | Content Pages | `content-page` | Static pages: about, partnership, baptism, stories, new-to-faith |
+| `sermon-series` | Sermon Series | `sermon-series` | Sermon series with embedded YouTube videos |
+| `site-settings` | Site Settings | `site-settings` | Singleton post for hero, about, contact, social, CTA (use ACF Pro options page if available) |
+
+### CPT UI Settings (for each)
+
+```
+Show in REST:        true
+REST Base:           (same as slug above)
+Supports:            title, custom-fields
+Has Archive:         false
+Public:              true
+Hierarchical:        false
+```
+
+### Ministry Page Slugs
+
+Each `ministry-page` post must have its WordPress slug match exactly:
+
+```
+life-groups, students, young-adults, kids, mens, womens,
+missions, deaf-ministry, care, prayer, serving, marriage-prep
+```
+
+### Content Page Slugs
+
+Each `content-page` post must have its WordPress slug match exactly:
+
+```
+about, partnership, baptism, stories, new-to-faith
+```
+
+---
+
+## ACF Field Groups
+
+### Site Settings
+
+> Attach to: Post Type = `site-settings` (or ACF Pro Options Page named "Site Settings")
+
+**Hero Section**
+
+| Field Name | Field Type | Notes |
+|------------|-----------|-------|
+| `hero_tagline` | Text | e.g. "No Perfect People Allowed" |
+| `hero_heading_prefix` | Text | e.g. "Jesus Changes" |
+| `hero_rotating_words` | Repeater | Subfield: `word` (Text). Each row is one rotating word |
+| `hero_description` | Textarea | Paragraph below the heading |
+| `hero_image` | Image | Return format: URL or Image Object. Hero background photo |
+| `hero_cta_primary_text` | Text | e.g. "Plan Your Visit" |
+| `hero_cta_primary_link` | Text (URL) | e.g. "/new" |
+| `hero_cta_secondary_text` | Text | e.g. "Watch Online" |
+| `hero_cta_secondary_link` | Text (URL) | e.g. "https://180life.online.church/" |
+
+**About Section**
+
+| Field Name | Field Type | Notes |
+|------------|-----------|-------|
+| `about_label` | Text | e.g. "Gather, Grow & Go" |
+| `about_heading` | Text | e.g. "A Place Where" |
+| `about_heading_accent` | Text | e.g. "You Belong" (rendered in amber) |
+| `about_body` | WYSIWYG | Split into paragraphs automatically by `<p>` tags |
+| `about_image` | Image | Community/church photo |
+| `about_link_text` | Text | e.g. "Learn More About Us" |
+| `about_link_url` | Text (URL) | e.g. "/about" |
+
+**Contact Info**
+
+| Field Name | Field Type | Notes |
+|------------|-----------|-------|
+| `contact_address_line1` | Text | e.g. "180 Still Road" |
+| `contact_address_line2` | Text | e.g. "Bloomfield, CT 06002" |
+| `contact_phone` | Text | e.g. "(860) 243-3576" |
+| `contact_email` | Email | e.g. "info@180lifechurch.org" |
+| `contact_service_times_summary` | Text | e.g. "Sundays at 9:00 & 11:00 AM" |
+| `doors_open_text` | Text | e.g. "Doors open at 8:40 AM" |
+
+**Social Media**
+
+| Field Name | Field Type | Notes |
+|------------|-----------|-------|
+| `social_facebook` | URL | Full Facebook page URL |
+| `social_instagram` | URL | Full Instagram profile URL |
+| `social_youtube` | URL | Full YouTube channel URL |
+| `social_vimeo` | URL | Full Vimeo channel URL (optional) |
+
+**Call-to-Action**
+
+| Field Name | Field Type | Notes |
+|------------|-----------|-------|
+| `cta_label` | Text | e.g. "Take Your Next Step" |
+| `cta_heading` | Text | e.g. "Your Story" |
+| `cta_heading_accent` | Text | e.g. "Starts Here" (rendered in amber) |
+| `cta_body` | Textarea | |
+| `cta_primary_text` | Text | e.g. "I'm New Here" |
+| `cta_primary_link` | Text (URL) | e.g. "/new" |
+| `cta_secondary_text` | Text | e.g. "Contact Us" |
+| `cta_secondary_link` | Text (URL) | e.g. "/contact" |
+
+**Global**
+
+| Field Name | Field Type | Notes |
+|------------|-----------|-------|
+| `mission_statement` | Textarea | e.g. "We exist to make and send disciples..." |
+| `church_tagline` | Text | e.g. "Jesus Changes Everything" |
+
+---
+
+### Events
+
+> Attach to: Post Type = `event`
+
+| Field Name | Field Type | Notes |
+|------------|-----------|-------|
+| `event_date` | Text | e.g. "April 20" (display format, not a date picker) |
+| `event_time` | Text | e.g. "9:00 AM & 11:00 AM" |
+| `event_description` | Textarea | Short description for the card |
+| `event_featured` | True/False | Featured events get a dark card style |
+| `event_link` | URL | Church Center or external registration link (optional) |
+
+---
+
+### Ministries (Homepage Cards)
+
+> Attach to: Post Type = `ministry`
+
+| Field Name | Field Type | Notes |
+|------------|-----------|-------|
+| `ministry_description` | Textarea | Short blurb for the homepage card |
+| `ministry_image` | Image | Card background image |
+| `ministry_tag` | Text | e.g. "Sundays", "Weekly", "Grades 6-12" |
+| `ministry_icon` | Select | Lucide icon name: Users, BookOpen, Baby, Sparkles, HandHeart, Music |
+| `ministry_sort_order` | Number | Display order on the homepage |
+
+---
+
+### Services
+
+> Attach to: Post Type = `service`
+
+| Field Name | Field Type | Notes |
+|------------|-----------|-------|
+| `service_day` | Text | e.g. "Sunday" |
+| `service_time` | Text | e.g. "9:00 AM" |
+| `service_description` | Textarea | |
+| `service_sort_order` | Number | Display order |
+
+---
+
+### Staff
+
+> Attach to: Post Type = `staff`
+
+The post **title** is the staff member's name.
+
+| Field Name | Field Type | Notes |
+|------------|-----------|-------|
+| `staff_role` | Text | e.g. "Lead Pastor", "Children's Ministry Director" |
+| `staff_photo` | Image | Headshot photo. Return format: URL or Image Object |
+| `staff_bio` | Textarea | Bio paragraph (optional) |
+
+**Important:** Staff whose role contains the word "Pastor" are automatically sorted into the Pastors section on the leadership page. All others appear in the Team section.
+
+---
+
+### Elders
+
+> Attach to: Post Type = `elder`
+
+The post **title** is the elder's name.
+
+| Field Name | Field Type | Notes |
+|------------|-----------|-------|
+| `elder_role` | Text | e.g. "Chair", "Secretary", "Treasurer", "Elder" |
+| `elder_photo` | Image | Headshot (optional) |
+
+---
+
+### Ministry Pages (Subpage Content)
+
+> Attach to: Post Type = `ministry-page`
+
+The post **title** is the ministry name. The post **slug** must match the route slug exactly (see list above).
+
+| Field Name | Field Type | Notes |
+|------------|-----------|-------|
+| `ministry_subtitle` | Textarea | Shown in the PageHero below the title |
+| `ministry_description` | WYSIWYG | Main body content. Split into paragraphs by `<p>` tags |
+| `ministry_schedule` | Repeater | Subfields: `day` (Text), `time` (Text), `location` (Text, optional) |
+| `ministry_contact_email` | Email | Contact email shown in the CTA section |
+| `ministry_external_links` | Repeater | Subfields: `label` (Text), `href` (URL), `description` (Text, optional). Used for Church Center links, Google Drive folders, etc. |
+
+---
+
+### Content Pages
+
+> Attach to: Post Type = `content-page`
+
+The post **title** is the page name. The post **slug** must match the route slug exactly.
+
+| Field Name | Field Type | Notes |
+|------------|-----------|-------|
+| `page_subtitle` | Textarea | Shown in the PageHero |
+| `page_sections` | Repeater | Each row is a content section. Subfields below |
+| `page_cta` | Group | CTA block at the bottom. Subfields below |
+
+**`page_sections` subfields:**
+
+| Subfield | Type | Notes |
+|----------|------|-------|
+| `label` | Text | Optional section label (e.g. "Our Mission") |
+| `heading` | Text | Section heading (e.g. "Following, Changing,") |
+| `heading_accent` | Text | Amber-colored word (e.g. "Committed") |
+| `body` | WYSIWYG | Section content. Split into paragraphs by `<p>` tags |
+| `image_src` | Image (URL) | Optional section image |
+| `image_alt` | Text | Image alt text |
+| `image_position` | Select | "left" or "right" (default: right) |
+
+**`page_cta` subfields:**
+
+| Subfield | Type | Notes |
+|----------|------|-------|
+| `heading` | Text | e.g. "Got Questions?" |
+| `description` | Textarea | Optional description |
+| `text` | Text | Button text (e.g. "Ask Now") |
+| `link` | URL | Button link. Can be internal ("/contact") or external ("https://...") |
+
+---
+
+### Sermon Series
+
+> Attach to: Post Type = `sermon-series`
+
+The post **title** is the series name.
+
+| Field Name | Field Type | Notes |
+|------------|-----------|-------|
+| `series_slug` | Text | URL slug (e.g. "at-the-movies"). Falls back to slugified title if empty |
+| `series_subtitle` | Text | Short tagline |
+| `series_description` | WYSIWYG | Longer description. Split by `<p>` tags |
+| `series_image` | Image | Series cover/thumbnail |
+| `series_sermons` | Repeater | Individual sermons in the series. Subfields below |
+
+**`series_sermons` subfields:**
+
+| Subfield | Type | Notes |
+|----------|------|-------|
+| `title` | Text | Sermon title |
+| `date` | Text | Display date (e.g. "February 2024") |
+| `youtube_id` | Text | YouTube video ID (e.g. "dQw4w9WgXcQ") |
+| `speaker` | Text | Speaker name (optional) |
+
+---
+
+## Webhook Configuration
+
+When editorial publishes or updates content in WordPress, the Next.js ISR cache
+must be invalidated so the site serves fresh data.
+
+### Option A: WP Webhooks Plugin (recommended)
+
+1. Install "WP Webhooks" (free tier)
+2. Go to WP Webhooks > Send Data > Post Updated
+3. Add a new webhook:
+   - **URL:** `https://180lifechurch.vercel.app/api/revalidate` (replace with your Vercel domain)
+   - **Method:** POST
+   - **Headers:** `x-revalidation-secret: YOUR_SECRET_HERE`
+4. Set it to trigger on: `publish`, `update`, `trash` for all relevant CPTs
+
+### Option B: Custom functions.php Hook
+
+Add to your theme's `functions.php` or a site-specific plugin:
+
+```php
+function trigger_nextjs_revalidation($post_id, $post, $update) {
+    // Only trigger for our custom post types
+    $tracked_types = [
+        'event', 'ministry', 'service', 'staff', 'elder',
+        'ministry-page', 'content-page', 'sermon-series', 'site-settings'
+    ];
+
+    if (!in_array($post->post_type, $tracked_types)) {
+        return;
+    }
+
+    // Only trigger on publish/update, not drafts
+    if ($post->post_status !== 'publish') {
+        return;
+    }
+
+    $vercel_url = 'https://180lifechurch.vercel.app/api/revalidate';
+    $secret = defined('NEXTJS_REVALIDATION_SECRET')
+        ? NEXTJS_REVALIDATION_SECRET
+        : '';
+
+    wp_remote_post($vercel_url, [
+        'headers' => [
+            'Content-Type'          => 'application/json',
+            'x-revalidation-secret' => $secret,
+        ],
+        'body'    => wp_json_encode(['post_id' => $post_id]),
+        'timeout' => 5,
+    ]);
+}
+add_action('save_post', 'trigger_nextjs_revalidation', 10, 3);
+```
+
+Then add to `wp-config.php`:
+
+```php
+define('NEXTJS_REVALIDATION_SECRET', 'your-secret-here');
+```
+
+---
+
+## Vercel Deployment Settings
+
+### Environment Variables
+
+In Vercel project dashboard (Settings > Environment Variables), add:
+
+| Key | Value | Environments |
+|-----|-------|-------------|
+| `WORDPRESS_URL` | `https://180lifechurch.org` | Production, Preview |
+| `WORDPRESS_REVALIDATION_SECRET` | (generate with `openssl rand -hex 32`) | Production, Preview |
+
+### ISR Behavior
+
+- **Default cache:** 1 hour (`revalidate: 3600` in fetch options)
+- **On-demand revalidation:** Instant via `POST /api/revalidate` webhook
+- **Cache tag:** All WordPress data is tagged `"wordpress"`. A single revalidation call clears all cached WP data across all pages.
+
+---
+
+## Testing the Integration
+
+### Step 1: Local Testing
+
+```bash
+# Add to .env.local
+WORDPRESS_URL=https://180lifechurch.org
+WORDPRESS_REVALIDATION_SECRET=test-secret-123
+
+# Start dev server
+npm run dev
+```
+
+If ACF fields are not yet configured in WordPress, the site will fall back to
+hardcoded content. Check the terminal for `WordPress API error` messages to
+confirm the fetch is being attempted.
+
+### Step 2: Verify REST API Access
+
+Test that the WordPress REST API is accessible:
+
+```bash
+# Should return JSON array of posts
+curl https://180lifechurch.org/wp-json/wp/v2/pages?per_page=1
+
+# Should return ACF options (if ACF Pro + ACF to REST API installed)
+curl https://180lifechurch.org/wp-json/acf/v3/options/site-settings
+```
+
+If you get a 404 or 403:
+- Ensure permalinks are set to anything other than "Plain" in WP Settings > Permalinks
+- Check that custom post types have `show_in_rest = true`
+- ACF fields need "Show in REST API" enabled in field group settings
+
+### Step 3: Test Revalidation
+
+```bash
+# Trigger cache clear
+curl -X POST https://your-vercel-url.com/api/revalidate \
+  -H "Content-Type: application/json" \
+  -H "x-revalidation-secret: YOUR_SECRET" \
+  -d '{}'
+```
+
+Expected response: `{"revalidated":true,"now":1234567890}`
+
+### Step 4: End-to-End Test
+
+1. Update a staff member's bio in WordPress
+2. Publish the change
+3. Wait 2-3 seconds for the webhook to fire
+4. Refresh the leadership page on the Vercel site
+5. The updated bio should appear
+
+---
+
+## Troubleshooting
+
+| Problem | Likely Cause | Fix |
+|---------|-------------|-----|
+| Site shows fallback content despite WP being configured | `WORDPRESS_URL` not set or typo | Check Vercel env vars; redeploy after adding |
+| 404 from WP REST API | CPT not registered with `show_in_rest` | Add `'show_in_rest' => true` to CPT registration |
+| ACF fields missing from API response | ACF REST support not enabled | In ACF field group settings, enable "Show in REST API" |
+| Stale content after WP update | Webhook not firing or wrong secret | Test webhook manually with curl; check secret matches |
+| Images not loading | Domain not in Next.js config | `180lifechurch.org` is already in `next.config.ts` `remotePatterns` |
+| Ministry page 404 | WP post slug does not match route | Ensure the WP slug matches exactly (e.g. `life-groups`, not `life_groups`) |
+| "WORDPRESS_URL not configured" in logs | Expected in local dev without `.env.local` | Add `WORDPRESS_URL` to `.env.local` or ignore (fallbacks work fine) |
+
+---
+
+## File Reference
+
+| File | Purpose |
+|------|---------|
+| `src/lib/data.ts` | **Import from here.** Unified data access layer. Tries WP, falls back to hardcoded |
+| `src/lib/wordpress.ts` | Raw WP REST API fetch functions and ACF field parsers |
+| `src/lib/wordpress-types.ts` | TypeScript interfaces for WP data shapes |
+| `src/lib/wordpress-fallbacks.ts` | Hardcoded homepage content (hero, about, events, services, etc.) |
+| `src/lib/subpage-fallbacks.ts` | Hardcoded subpage content (ministries, content pages, leadership, sermons) |
+| `src/lib/subpage-types.ts` | TypeScript interfaces for subpage data shapes |
+| `src/app/api/revalidate/route.ts` | Webhook endpoint for on-demand ISR cache clearing |
+| `next.config.ts` | Image remote patterns (already includes `180lifechurch.org`) |

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -3,16 +3,13 @@ import { Footer } from "@/components/Footer";
 import { PageHero } from "@/components/PageHero";
 import { ContentSection } from "@/components/ContentSection";
 import { FadeIn } from "@/components/FadeIn";
-import { getFooterProps } from "@/lib/wordpress-fallbacks";
-import { CONTENT_PAGES } from "@/lib/subpage-fallbacks";
+import { fetchFooterProps, fetchContentPage } from "@/lib/data";
 import { Users, Heart, BookOpen, HandHeart, ArrowRight } from "lucide-react";
 import type { Metadata } from "next";
 
-const data = CONTENT_PAGES["about"];
-
 export const metadata: Metadata = {
   title: "About Us | 180 Life Church",
-  description: data.subtitle,
+  description: "We exist to make and send disciples who love and live like Jesus.",
 };
 
 const nextSteps = [
@@ -50,8 +47,13 @@ const nextSteps = [
   },
 ];
 
-export default function AboutPage() {
-  const footerProps = getFooterProps();
+export default async function AboutPage() {
+  const [footerProps, data] = await Promise.all([
+    fetchFooterProps(),
+    fetchContentPage("about"),
+  ]);
+
+  if (!data) return null;
 
   return (
     <>

--- a/src/app/baptism/page.tsx
+++ b/src/app/baptism/page.tsx
@@ -1,14 +1,21 @@
 import { ContentPageTemplate } from "@/components/templates/ContentPageTemplate";
-import { CONTENT_PAGES } from "@/lib/subpage-fallbacks";
+import { fetchContentPage } from "@/lib/data";
+import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 
-const data = CONTENT_PAGES["baptism"];
+const SLUG = "baptism";
 
-export const metadata: Metadata = {
-  title: "Baptism | 180 Life Church",
-  description: data.subtitle,
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const data = await fetchContentPage(SLUG);
+  if (!data) return {};
+  return {
+    title: `${data.title} | 180 Life Church`,
+    description: data.subtitle,
+  };
+}
 
-export default function BaptismPage() {
+export default async function Page() {
+  const data = await fetchContentPage(SLUG);
+  if (!data) notFound();
   return <ContentPageTemplate data={data} />;
 }

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -3,7 +3,7 @@ import { Footer } from "@/components/Footer";
 import { PageHero } from "@/components/PageHero";
 import { ContactForm } from "@/components/ContactForm";
 import { FadeIn } from "@/components/FadeIn";
-import { getFooterProps, FALLBACK_SETTINGS } from "@/lib/wordpress-fallbacks";
+import { fetchFooterProps, fetchSiteSettings } from "@/lib/data";
 import { MapPin, Phone, Mail, Clock } from "lucide-react";
 import type { Metadata } from "next";
 
@@ -13,9 +13,12 @@ export const metadata: Metadata = {
     "Get in touch with 180 Life Church in Bloomfield, CT. Send us a message, submit a prayer request, or plan your visit.",
 };
 
-export default function ContactPage() {
-  const footerProps = getFooterProps();
-  const { contact } = FALLBACK_SETTINGS;
+export default async function ContactPage() {
+  const [footerProps, settings] = await Promise.all([
+    fetchFooterProps(),
+    fetchSiteSettings(),
+  ]);
+  const { contact } = settings;
 
   return (
     <>

--- a/src/app/give/page.tsx
+++ b/src/app/give/page.tsx
@@ -2,7 +2,7 @@ import { Navbar } from "@/components/Navbar";
 import { Footer } from "@/components/Footer";
 import { PageHero } from "@/components/PageHero";
 import { FadeIn } from "@/components/FadeIn";
-import { getFooterProps } from "@/lib/wordpress-fallbacks";
+import { fetchFooterProps } from "@/lib/data";
 import {
   Heart,
   Shield,
@@ -21,8 +21,8 @@ export const metadata: Metadata = {
     "Support the mission of 180 Life Church through your generous giving. Give online, by text, in person, or by mail.",
 };
 
-export default function GivePage() {
-  const footerProps = getFooterProps();
+export default async function GivePage() {
+  const footerProps = await fetchFooterProps();
 
   return (
     <>
@@ -90,7 +90,7 @@ export default function GivePage() {
               one-time gift or set up recurring giving.
             </p>
             <a
-              href="https://180lifechurch.churchcenter.com/giving"
+              href="https://180life.churchcenter.com/giving"
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-3 px-10 py-4 bg-amber text-charcoal font-bold rounded-full hover:bg-amber-light transition-all hover:shadow-2xl hover:shadow-amber/30 text-lg hover:scale-105"
@@ -192,6 +192,15 @@ export default function GivePage() {
                     Contact us to find out when the next FPU class begins at 180
                     Life Church.
                   </p>
+                  <a
+                    href="https://www.ramseysolutions.com/ramseyplus/financial-peace"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-2 text-amber font-semibold text-sm mt-3 hover:underline"
+                  >
+                    Learn More About FPU
+                    <span>&rarr;</span>
+                  </a>
                 </div>
               </div>
             </div>

--- a/src/app/leadership/page.tsx
+++ b/src/app/leadership/page.tsx
@@ -3,13 +3,14 @@ import { Footer } from "@/components/Footer";
 import { PageHero } from "@/components/PageHero";
 import { StaffCard } from "@/components/StaffCard";
 import { FadeIn } from "@/components/FadeIn";
-import { getFooterProps } from "@/lib/wordpress-fallbacks";
+import Image from "next/image";
 import {
-  LEADERSHIP_DATA,
-  ELDERS,
+  fetchFooterProps,
+  fetchLeadership,
+  fetchElders,
   ELDERS_DESCRIPTION,
   ELDERS_EMAIL,
-} from "@/lib/subpage-fallbacks";
+} from "@/lib/data";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -18,8 +19,12 @@ export const metadata: Metadata = {
     "Meet the pastors and staff who lead 180 Life Church in Bloomfield, CT.",
 };
 
-export default function LeadershipPage() {
-  const footerProps = getFooterProps();
+export default async function LeadershipPage() {
+  const [footerProps, leadershipData, elders] = await Promise.all([
+    fetchFooterProps(),
+    fetchLeadership(),
+    fetchElders(),
+  ]);
 
   return (
     <>
@@ -42,7 +47,7 @@ export default function LeadershipPage() {
             </h2>
           </FadeIn>
           <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-8 justify-center">
-            {LEADERSHIP_DATA.pastors.map((pastor, i) => (
+            {leadershipData.pastors.map((pastor, i) => (
               <StaffCard
                 key={pastor.name}
                 name={pastor.name}
@@ -57,7 +62,7 @@ export default function LeadershipPage() {
       </section>
 
       {/* Staff */}
-      {LEADERSHIP_DATA.staff.length > 0 && (
+      {leadershipData.staff.length > 0 && (
         <section className="bg-white py-16 sm:py-20">
           <div className="max-w-5xl mx-auto px-6">
             <FadeIn>
@@ -69,7 +74,7 @@ export default function LeadershipPage() {
               </h2>
             </FadeIn>
             <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-8">
-              {LEADERSHIP_DATA.staff.map((member, i) => (
+              {leadershipData.staff.map((member, i) => (
                 <StaffCard
                   key={member.name}
                   name={member.name}
@@ -99,11 +104,24 @@ export default function LeadershipPage() {
             </p>
           </FadeIn>
           <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
-            {ELDERS.map((elder, i) => (
+            {elders.map((elder, i) => (
               <FadeIn key={elder.name} delay={i * 0.05}>
-                <div className="bg-white rounded-2xl border border-charcoal/8 p-6 text-center">
-                  <h3 className="font-bold text-charcoal">{elder.name}</h3>
-                  <p className="text-amber text-sm mt-1">{elder.role}</p>
+                <div className="bg-white rounded-2xl border border-charcoal/8 overflow-hidden text-center">
+                  {elder.image && (
+                    <div className="relative aspect-[3/4] overflow-hidden">
+                      <Image
+                        src={elder.image}
+                        alt={elder.name}
+                        fill
+                        className="object-cover"
+                        sizes="(max-width: 640px) 50vw, 25vw"
+                      />
+                    </div>
+                  )}
+                  <div className="p-6">
+                    <h3 className="font-bold text-charcoal">{elder.name}</h3>
+                    <p className="text-amber text-sm mt-1">{elder.role}</p>
+                  </div>
                 </div>
               </FadeIn>
             ))}

--- a/src/app/ministries/care/page.tsx
+++ b/src/app/ministries/care/page.tsx
@@ -1,14 +1,21 @@
 import { MinistryPageTemplate } from "@/components/templates/MinistryPageTemplate";
-import { MINISTRY_PAGES } from "@/lib/subpage-fallbacks";
+import { fetchMinistryPage } from "@/lib/data";
+import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 
-const data = MINISTRY_PAGES["care"];
+const SLUG = "care";
 
-export const metadata: Metadata = {
-  title: `${data.title} | 180 Life Church`,
-  description: data.subtitle,
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const data = await fetchMinistryPage(SLUG);
+  if (!data) return {};
+  return {
+    title: `${data.title} | 180 Life Church`,
+    description: data.subtitle,
+  };
+}
 
-export default function CareMinistryPage() {
+export default async function Page() {
+  const data = await fetchMinistryPage(SLUG);
+  if (!data) notFound();
   return <MinistryPageTemplate data={data} />;
 }

--- a/src/app/ministries/deaf-ministry/page.tsx
+++ b/src/app/ministries/deaf-ministry/page.tsx
@@ -1,14 +1,21 @@
 import { MinistryPageTemplate } from "@/components/templates/MinistryPageTemplate";
-import { MINISTRY_PAGES } from "@/lib/subpage-fallbacks";
+import { fetchMinistryPage } from "@/lib/data";
+import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 
-const data = MINISTRY_PAGES["deaf-ministry"];
+const SLUG = "deaf-ministry";
 
-export const metadata: Metadata = {
-  title: `${data.title} | 180 Life Church`,
-  description: data.subtitle,
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const data = await fetchMinistryPage(SLUG);
+  if (!data) return {};
+  return {
+    title: `${data.title} | 180 Life Church`,
+    description: data.subtitle,
+  };
+}
 
-export default function DeafMinistryPage() {
+export default async function Page() {
+  const data = await fetchMinistryPage(SLUG);
+  if (!data) notFound();
   return <MinistryPageTemplate data={data} />;
 }

--- a/src/app/ministries/kids/page.tsx
+++ b/src/app/ministries/kids/page.tsx
@@ -1,14 +1,21 @@
 import { MinistryPageTemplate } from "@/components/templates/MinistryPageTemplate";
-import { MINISTRY_PAGES } from "@/lib/subpage-fallbacks";
+import { fetchMinistryPage } from "@/lib/data";
+import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 
-const data = MINISTRY_PAGES["kids"];
+const SLUG = "kids";
 
-export const metadata: Metadata = {
-  title: `${data.title} | 180 Life Church`,
-  description: data.subtitle,
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const data = await fetchMinistryPage(SLUG);
+  if (!data) return {};
+  return {
+    title: `${data.title} | 180 Life Church`,
+    description: data.subtitle,
+  };
+}
 
-export default function KidsPage() {
+export default async function Page() {
+  const data = await fetchMinistryPage(SLUG);
+  if (!data) notFound();
   return <MinistryPageTemplate data={data} />;
 }

--- a/src/app/ministries/life-groups/page.tsx
+++ b/src/app/ministries/life-groups/page.tsx
@@ -1,14 +1,21 @@
 import { MinistryPageTemplate } from "@/components/templates/MinistryPageTemplate";
-import { MINISTRY_PAGES } from "@/lib/subpage-fallbacks";
+import { fetchMinistryPage } from "@/lib/data";
+import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 
-const data = MINISTRY_PAGES["life-groups"];
+const SLUG = "life-groups";
 
-export const metadata: Metadata = {
-  title: `${data.title} | 180 Life Church`,
-  description: data.subtitle,
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const data = await fetchMinistryPage(SLUG);
+  if (!data) return {};
+  return {
+    title: `${data.title} | 180 Life Church`,
+    description: data.subtitle,
+  };
+}
 
-export default function LifeGroupsPage() {
+export default async function Page() {
+  const data = await fetchMinistryPage(SLUG);
+  if (!data) notFound();
   return <MinistryPageTemplate data={data} />;
 }

--- a/src/app/ministries/marriage-prep/page.tsx
+++ b/src/app/ministries/marriage-prep/page.tsx
@@ -1,14 +1,21 @@
 import { MinistryPageTemplate } from "@/components/templates/MinistryPageTemplate";
-import { MINISTRY_PAGES } from "@/lib/subpage-fallbacks";
+import { fetchMinistryPage } from "@/lib/data";
+import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 
-const data = MINISTRY_PAGES["marriage-prep"];
+const SLUG = "marriage-prep";
 
-export const metadata: Metadata = {
-  title: `${data.title} | 180 Life Church`,
-  description: data.subtitle,
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const data = await fetchMinistryPage(SLUG);
+  if (!data) return {};
+  return {
+    title: `${data.title} | 180 Life Church`,
+    description: data.subtitle,
+  };
+}
 
-export default function MarriagePrepPage() {
+export default async function Page() {
+  const data = await fetchMinistryPage(SLUG);
+  if (!data) notFound();
   return <MinistryPageTemplate data={data} />;
 }

--- a/src/app/ministries/mens/page.tsx
+++ b/src/app/ministries/mens/page.tsx
@@ -1,14 +1,21 @@
 import { MinistryPageTemplate } from "@/components/templates/MinistryPageTemplate";
-import { MINISTRY_PAGES } from "@/lib/subpage-fallbacks";
+import { fetchMinistryPage } from "@/lib/data";
+import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 
-const data = MINISTRY_PAGES["mens"];
+const SLUG = "mens";
 
-export const metadata: Metadata = {
-  title: `${data.title} | 180 Life Church`,
-  description: data.subtitle,
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const data = await fetchMinistryPage(SLUG);
+  if (!data) return {};
+  return {
+    title: `${data.title} | 180 Life Church`,
+    description: data.subtitle,
+  };
+}
 
-export default function MensMinistryPage() {
+export default async function Page() {
+  const data = await fetchMinistryPage(SLUG);
+  if (!data) notFound();
   return <MinistryPageTemplate data={data} />;
 }

--- a/src/app/ministries/missions/page.tsx
+++ b/src/app/ministries/missions/page.tsx
@@ -1,14 +1,21 @@
 import { MinistryPageTemplate } from "@/components/templates/MinistryPageTemplate";
-import { MINISTRY_PAGES } from "@/lib/subpage-fallbacks";
+import { fetchMinistryPage } from "@/lib/data";
+import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 
-const data = MINISTRY_PAGES["missions"];
+const SLUG = "missions";
 
-export const metadata: Metadata = {
-  title: `${data.title} | 180 Life Church`,
-  description: data.subtitle,
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const data = await fetchMinistryPage(SLUG);
+  if (!data) return {};
+  return {
+    title: `${data.title} | 180 Life Church`,
+    description: data.subtitle,
+  };
+}
 
-export default function MissionsPage() {
+export default async function Page() {
+  const data = await fetchMinistryPage(SLUG);
+  if (!data) notFound();
   return <MinistryPageTemplate data={data} />;
 }

--- a/src/app/ministries/page.tsx
+++ b/src/app/ministries/page.tsx
@@ -3,8 +3,7 @@ import { Navbar } from "@/components/Navbar";
 import { Footer } from "@/components/Footer";
 import { PageHero } from "@/components/PageHero";
 import { FadeIn } from "@/components/FadeIn";
-import { getFooterProps } from "@/lib/wordpress-fallbacks";
-import { MINISTRY_PAGES } from "@/lib/subpage-fallbacks";
+import { fetchFooterProps, fetchAllMinistryPages } from "@/lib/data";
 import {
   Users,
   BookOpen,
@@ -113,8 +112,10 @@ const heroImages: Record<string, string> = {
 /* Schedule badge helper                                               */
 /* ------------------------------------------------------------------ */
 
-function ScheduleBadge({ slug }: { slug: string }) {
-  const data = MINISTRY_PAGES[slug];
+import type { MinistryPageData } from "@/lib/subpage-types";
+
+function ScheduleBadge({ slug, pages }: { slug: string; pages: Record<string, MinistryPageData> }) {
+  const data = pages[slug];
   const sched = data?.schedule?.[0];
   if (!sched) return null;
 
@@ -130,8 +131,8 @@ function ScheduleBadge({ slug }: { slug: string }) {
 /* Hero Card (photo background, col-span-2)                            */
 /* ------------------------------------------------------------------ */
 
-function HeroCard({ slug }: { slug: string }) {
-  const data = MINISTRY_PAGES[slug];
+function HeroCard({ slug, pages }: { slug: string; pages: Record<string, MinistryPageData> }) {
+  const data = pages[slug];
   if (!data) return null;
   const Icon = iconMap[slug] ?? HandHeart;
   const image = heroImages[slug];
@@ -178,7 +179,7 @@ function HeroCard({ slug }: { slug: string }) {
             <p className="text-white/60 text-sm sm:text-base leading-relaxed mb-1 max-w-lg group-hover:text-white/80 transition-colors duration-300">
               {data.subtitle}
             </p>
-            <ScheduleBadge slug={slug} />
+            <ScheduleBadge slug={slug} pages={pages} />
 
             {/* Action row */}
             <div className="flex items-center gap-2 pt-4 mt-3 border-t border-white/10 group-hover:border-white/20 transition-colors">
@@ -204,11 +205,13 @@ function HeroCard({ slug }: { slug: string }) {
 function StandardCard({
   slug,
   delay = 0,
+  pages,
 }: {
   slug: string;
   delay?: number;
+  pages: Record<string, MinistryPageData>;
 }) {
-  const data = MINISTRY_PAGES[slug];
+  const data = pages[slug];
   if (!data) return null;
   const Icon = iconMap[slug] ?? HandHeart;
   const color = colorMap[slug] ?? "from-charcoal/80 to-charcoal/90";
@@ -252,7 +255,7 @@ function StandardCard({
             <p className="text-white/60 text-sm leading-relaxed line-clamp-2 group-hover:text-white/80 transition-colors duration-300">
               {data.subtitle}
             </p>
-            <ScheduleBadge slug={slug} />
+            <ScheduleBadge slug={slug} pages={pages} />
 
             {/* Action row */}
             <div className="flex items-center gap-2 pt-3 mt-2 border-t border-white/10 group-hover:border-white/20 transition-colors">
@@ -275,8 +278,11 @@ function StandardCard({
 /* Page Component                                                      */
 /* ------------------------------------------------------------------ */
 
-export default function MinistriesPage() {
-  const footerProps = getFooterProps();
+export default async function MinistriesPage() {
+  const [footerProps, pages] = await Promise.all([
+    fetchFooterProps(),
+    fetchAllMinistryPages(),
+  ]);
 
   return (
     <>
@@ -321,7 +327,7 @@ export default function MinistriesPage() {
               {/* Grid: hero card (2 cols) + standard cards (1 col each) */}
               <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
                 {/* Hero card first */}
-                <HeroCard slug={group.featured} />
+                <HeroCard slug={group.featured} pages={pages} />
 
                 {/* Remaining standard cards */}
                 {nonFeatured.map((slug, i) => (
@@ -329,6 +335,7 @@ export default function MinistriesPage() {
                     key={slug}
                     slug={slug}
                     delay={0.05 * (i + 1)}
+                    pages={pages}
                   />
                 ))}
               </div>

--- a/src/app/ministries/prayer/page.tsx
+++ b/src/app/ministries/prayer/page.tsx
@@ -1,14 +1,21 @@
 import { MinistryPageTemplate } from "@/components/templates/MinistryPageTemplate";
-import { MINISTRY_PAGES } from "@/lib/subpage-fallbacks";
+import { fetchMinistryPage } from "@/lib/data";
+import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 
-const data = MINISTRY_PAGES["prayer"];
+const SLUG = "prayer";
 
-export const metadata: Metadata = {
-  title: `${data.title} | 180 Life Church`,
-  description: data.subtitle,
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const data = await fetchMinistryPage(SLUG);
+  if (!data) return {};
+  return {
+    title: `${data.title} | 180 Life Church`,
+    description: data.subtitle,
+  };
+}
 
-export default function PrayerMinistryPage() {
+export default async function Page() {
+  const data = await fetchMinistryPage(SLUG);
+  if (!data) notFound();
   return <MinistryPageTemplate data={data} />;
 }

--- a/src/app/ministries/serving/page.tsx
+++ b/src/app/ministries/serving/page.tsx
@@ -1,14 +1,21 @@
 import { MinistryPageTemplate } from "@/components/templates/MinistryPageTemplate";
-import { MINISTRY_PAGES } from "@/lib/subpage-fallbacks";
+import { fetchMinistryPage } from "@/lib/data";
+import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 
-const data = MINISTRY_PAGES["serving"];
+const SLUG = "serving";
 
-export const metadata: Metadata = {
-  title: `${data.title} | 180 Life Church`,
-  description: data.subtitle,
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const data = await fetchMinistryPage(SLUG);
+  if (!data) return {};
+  return {
+    title: `${data.title} | 180 Life Church`,
+    description: data.subtitle,
+  };
+}
 
-export default function ServingTeamsPage() {
+export default async function Page() {
+  const data = await fetchMinistryPage(SLUG);
+  if (!data) notFound();
   return <MinistryPageTemplate data={data} />;
 }

--- a/src/app/ministries/students/page.tsx
+++ b/src/app/ministries/students/page.tsx
@@ -1,14 +1,21 @@
 import { MinistryPageTemplate } from "@/components/templates/MinistryPageTemplate";
-import { MINISTRY_PAGES } from "@/lib/subpage-fallbacks";
+import { fetchMinistryPage } from "@/lib/data";
+import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 
-const data = MINISTRY_PAGES["students"];
+const SLUG = "students";
 
-export const metadata: Metadata = {
-  title: `${data.title} | 180 Life Church`,
-  description: data.subtitle,
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const data = await fetchMinistryPage(SLUG);
+  if (!data) return {};
+  return {
+    title: `${data.title} | 180 Life Church`,
+    description: data.subtitle,
+  };
+}
 
-export default function StudentsPage() {
+export default async function Page() {
+  const data = await fetchMinistryPage(SLUG);
+  if (!data) notFound();
   return <MinistryPageTemplate data={data} />;
 }

--- a/src/app/ministries/womens/page.tsx
+++ b/src/app/ministries/womens/page.tsx
@@ -1,14 +1,21 @@
 import { MinistryPageTemplate } from "@/components/templates/MinistryPageTemplate";
-import { MINISTRY_PAGES } from "@/lib/subpage-fallbacks";
+import { fetchMinistryPage } from "@/lib/data";
+import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 
-const data = MINISTRY_PAGES["womens"];
+const SLUG = "womens";
 
-export const metadata: Metadata = {
-  title: `${data.title} | 180 Life Church`,
-  description: data.subtitle,
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const data = await fetchMinistryPage(SLUG);
+  if (!data) return {};
+  return {
+    title: `${data.title} | 180 Life Church`,
+    description: data.subtitle,
+  };
+}
 
-export default function WomensMinistryPage() {
+export default async function Page() {
+  const data = await fetchMinistryPage(SLUG);
+  if (!data) notFound();
   return <MinistryPageTemplate data={data} />;
 }

--- a/src/app/ministries/young-adults/page.tsx
+++ b/src/app/ministries/young-adults/page.tsx
@@ -1,14 +1,21 @@
 import { MinistryPageTemplate } from "@/components/templates/MinistryPageTemplate";
-import { MINISTRY_PAGES } from "@/lib/subpage-fallbacks";
+import { fetchMinistryPage } from "@/lib/data";
+import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 
-const data = MINISTRY_PAGES["young-adults"];
+const SLUG = "young-adults";
 
-export const metadata: Metadata = {
-  title: `${data.title} | 180 Life Church`,
-  description: data.subtitle,
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const data = await fetchMinistryPage(SLUG);
+  if (!data) return {};
+  return {
+    title: `${data.title} | 180 Life Church`,
+    description: data.subtitle,
+  };
+}
 
-export default function YoungAdultsPage() {
+export default async function Page() {
+  const data = await fetchMinistryPage(SLUG);
+  if (!data) notFound();
   return <MinistryPageTemplate data={data} />;
 }

--- a/src/app/new-to-faith/page.tsx
+++ b/src/app/new-to-faith/page.tsx
@@ -1,15 +1,21 @@
 import { ContentPageTemplate } from "@/components/templates/ContentPageTemplate";
-import { CONTENT_PAGES } from "@/lib/subpage-fallbacks";
+import { fetchContentPage } from "@/lib/data";
+import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 
-const data = CONTENT_PAGES["new-to-faith"];
+const SLUG = "new-to-faith";
 
-export const metadata: Metadata = {
-  title: "New to Faith | 180 Life Church",
-  description:
-    "Did you recently give your life to Christ? We are here to help you start your journey with Bible resources, devotionals, and community.",
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const data = await fetchContentPage(SLUG);
+  if (!data) return {};
+  return {
+    title: `${data.title} | 180 Life Church`,
+    description: data.subtitle,
+  };
+}
 
-export default function NewToFaithPage() {
+export default async function Page() {
+  const data = await fetchContentPage(SLUG);
+  if (!data) notFound();
   return <ContentPageTemplate data={data} />;
 }

--- a/src/app/new/page.tsx
+++ b/src/app/new/page.tsx
@@ -2,7 +2,7 @@ import { Navbar } from "@/components/Navbar";
 import { Footer } from "@/components/Footer";
 import { PageHero } from "@/components/PageHero";
 import { FadeIn } from "@/components/FadeIn";
-import { getFooterProps, FALLBACK_SETTINGS } from "@/lib/wordpress-fallbacks";
+import { fetchFooterProps, fetchSiteSettings } from "@/lib/data";
 import {
   MapPin,
   Clock,
@@ -20,9 +20,12 @@ export const metadata: Metadata = {
     "Planning your first visit to 180 Life Church? Here is everything you need to know about what to expect, what to wear, and where to go.",
 };
 
-export default function NewHerePage() {
-  const footerProps = getFooterProps();
-  const { contact } = FALLBACK_SETTINGS;
+export default async function NewHerePage() {
+  const [footerProps, settings] = await Promise.all([
+    fetchFooterProps(),
+    fetchSiteSettings(),
+  ]);
+  const { contact } = settings;
 
   const whatToExpect = [
     {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,25 +8,18 @@ import { Events } from "@/components/Events";
 import { VisitCTA } from "@/components/VisitCTA";
 import { Footer } from "@/components/Footer";
 import {
-  getEvents,
-  getMinistries,
-  getServices,
-  getSiteSettings,
-} from "@/lib/wordpress";
-import {
-  FALLBACK_EVENTS,
-  FALLBACK_MINISTRIES,
-  FALLBACK_SERVICES,
-  FALLBACK_SETTINGS,
-} from "@/lib/wordpress-fallbacks";
+  fetchEvents,
+  fetchMinistries,
+  fetchServices,
+  fetchSiteSettings,
+} from "@/lib/data";
 
 export default async function Home() {
-  // Fetch all WordPress data in parallel, falling back to hardcoded defaults
   const [events, ministries, services, settings] = await Promise.all([
-    getEvents().catch(() => FALLBACK_EVENTS),
-    getMinistries().catch(() => FALLBACK_MINISTRIES),
-    getServices().catch(() => FALLBACK_SERVICES),
-    getSiteSettings().catch(() => FALLBACK_SETTINGS),
+    fetchEvents(),
+    fetchMinistries(),
+    fetchServices(),
+    fetchSiteSettings(),
   ]);
 
   return (

--- a/src/app/partnership/page.tsx
+++ b/src/app/partnership/page.tsx
@@ -1,14 +1,21 @@
 import { ContentPageTemplate } from "@/components/templates/ContentPageTemplate";
-import { CONTENT_PAGES } from "@/lib/subpage-fallbacks";
+import { fetchContentPage } from "@/lib/data";
+import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 
-const data = CONTENT_PAGES["partnership"];
+const SLUG = "partnership";
 
-export const metadata: Metadata = {
-  title: "Partnership | 180 Life Church",
-  description: data.subtitle,
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const data = await fetchContentPage(SLUG);
+  if (!data) return {};
+  return {
+    title: `${data.title} | 180 Life Church`,
+    description: data.subtitle,
+  };
+}
 
-export default function PartnershipPage() {
+export default async function Page() {
+  const data = await fetchContentPage(SLUG);
+  if (!data) notFound();
   return <ContentPageTemplate data={data} />;
 }

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -2,7 +2,7 @@ import { Navbar } from "@/components/Navbar";
 import { Footer } from "@/components/Footer";
 import { PageHero } from "@/components/PageHero";
 import { FadeIn } from "@/components/FadeIn";
-import { getFooterProps } from "@/lib/wordpress-fallbacks";
+import { fetchFooterProps } from "@/lib/data";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -11,8 +11,8 @@ export const metadata: Metadata = {
     "Privacy policy for 180 Life Church. Learn how we collect, use, and protect your personal information.",
 };
 
-export default function PrivacyPage() {
-  const footerProps = getFooterProps();
+export default async function PrivacyPage() {
+  const footerProps = await fetchFooterProps();
 
   return (
     <>

--- a/src/app/sermons/[slug]/page.tsx
+++ b/src/app/sermons/[slug]/page.tsx
@@ -1,5 +1,9 @@
 import { SermonSeriesTemplate } from "@/components/templates/SermonSeriesTemplate";
-import { SERMON_SERIES, ALL_SERIES_SLUGS } from "@/lib/subpage-fallbacks";
+import {
+  fetchSermonSeriesBySlug,
+  fetchAllSermonSeries,
+  getAllSeriesSlugs,
+} from "@/lib/data";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 
@@ -8,12 +12,13 @@ interface Props {
 }
 
 export async function generateStaticParams() {
-  return ALL_SERIES_SLUGS.map((slug) => ({ slug }));
+  const slugs = await getAllSeriesSlugs();
+  return slugs.map((slug) => ({ slug }));
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
-  const series = SERMON_SERIES[slug];
+  const series = await fetchSermonSeriesBySlug(slug);
   if (!series) return {};
 
   return {
@@ -24,14 +29,15 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function SermonSeriesPage({ params }: Props) {
   const { slug } = await params;
-  const series = SERMON_SERIES[slug];
+  const series = await fetchSermonSeriesBySlug(slug);
 
   if (!series) {
     notFound();
   }
 
   // Add related series (all except current)
-  const related = Object.values(SERMON_SERIES)
+  const allSeries = await fetchAllSermonSeries();
+  const related = Object.values(allSeries)
     .filter((s) => s.slug !== slug)
     .map((s) => ({
       title: s.title,

--- a/src/app/sermons/page.tsx
+++ b/src/app/sermons/page.tsx
@@ -3,8 +3,7 @@ import { Navbar } from "@/components/Navbar";
 import { Footer } from "@/components/Footer";
 import { PageHero } from "@/components/PageHero";
 import { FadeIn } from "@/components/FadeIn";
-import { getFooterProps } from "@/lib/wordpress-fallbacks";
-import { SERMON_SERIES } from "@/lib/subpage-fallbacks";
+import { fetchFooterProps, fetchAllSermonSeries } from "@/lib/data";
 import { Play, Youtube } from "lucide-react";
 import type { Metadata } from "next";
 
@@ -14,9 +13,12 @@ export const metadata: Metadata = {
     "Watch and listen to sermons from 180 Life Church. Browse our sermon series and catch up on messages you missed.",
 };
 
-export default function SermonsPage() {
-  const footerProps = getFooterProps();
-  const allSeries = Object.values(SERMON_SERIES);
+export default async function SermonsPage() {
+  const [footerProps, sermonData] = await Promise.all([
+    fetchFooterProps(),
+    fetchAllSermonSeries(),
+  ]);
+  const allSeries = Object.values(sermonData);
 
   return (
     <>
@@ -27,9 +29,9 @@ export default function SermonsPage() {
         breadcrumbs={[{ label: "Sermons", href: "/sermons" }]}
       />
 
-      {/* Browse by YouTube */}
+      {/* Browse by YouTube + Message Archive */}
       <section className="bg-soft-white py-10">
-        <div className="max-w-3xl mx-auto px-6 text-center">
+        <div className="max-w-3xl mx-auto px-6 text-center flex flex-wrap items-center justify-center gap-4">
           <FadeIn>
             <a
               href="https://www.youtube.com/@180lifechurch"
@@ -39,6 +41,17 @@ export default function SermonsPage() {
             >
               <Youtube className="text-red-600" size={20} />
               Watch on YouTube
+            </a>
+          </FadeIn>
+          <FadeIn delay={0.1}>
+            <a
+              href="https://180life.churchcenter.com/channels/12038/series"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-6 py-3 bg-white border border-charcoal/10 rounded-full text-charcoal font-medium hover:border-amber/30 hover:shadow-md transition-all"
+            >
+              <Play className="text-amber" size={20} />
+              Message Archive
             </a>
           </FadeIn>
         </div>

--- a/src/app/stories/page.tsx
+++ b/src/app/stories/page.tsx
@@ -1,14 +1,21 @@
 import { ContentPageTemplate } from "@/components/templates/ContentPageTemplate";
-import { CONTENT_PAGES } from "@/lib/subpage-fallbacks";
+import { fetchContentPage } from "@/lib/data";
+import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 
-const data = CONTENT_PAGES["stories"];
+const SLUG = "stories";
 
-export const metadata: Metadata = {
-  title: "Stories | 180 Life Church",
-  description: data.subtitle,
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const data = await fetchContentPage(SLUG);
+  if (!data) return {};
+  return {
+    title: `${data.title} | 180 Life Church`,
+    description: data.subtitle,
+  };
+}
 
-export default function StoriesPage() {
+export default async function Page() {
+  const data = await fetchContentPage(SLUG);
+  if (!data) notFound();
   return <ContentPageTemplate data={data} />;
 }

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -2,7 +2,7 @@ import { Navbar } from "@/components/Navbar";
 import { Footer } from "@/components/Footer";
 import { PageHero } from "@/components/PageHero";
 import { FadeIn } from "@/components/FadeIn";
-import { getFooterProps } from "@/lib/wordpress-fallbacks";
+import { fetchFooterProps } from "@/lib/data";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -11,8 +11,8 @@ export const metadata: Metadata = {
     "Terms of use for the 180 Life Church website.",
 };
 
-export default function TermsPage() {
-  const footerProps = getFooterProps();
+export default async function TermsPage() {
+  const footerProps = await fetchFooterProps();
 
   return (
     <>

--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -93,7 +93,7 @@ export function Events({ events }: EventsProps) {
         <FadeIn delay={0.4}>
           <div className="text-center mt-12">
             <a
-              href="https://180lifechurch.churchcenter.com/registrations"
+              href="https://180life.churchcenter.com/registrations/events/campus/13393"
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center text-amber-dark font-semibold hover:text-amber transition-colors group text-lg"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,18 +5,20 @@ import type { WPContactData, WPSocialData } from "@/lib/wordpress-types";
 const quickLinks = [
   { label: "About", href: "/about" },
   { label: "Leadership", href: "/leadership" },
-  { label: "Services", href: "/#services" },
   { label: "Ministries", href: "/ministries" },
   { label: "Sermons", href: "/sermons" },
+  { label: "Events", href: "https://180life.churchcenter.com/pages/events-landing-page", external: true },
   { label: "Give", href: "/give" },
+  { label: "Watch Live", href: "https://180life.online.church/", external: true },
 ];
 
 const connectLinks = [
   { label: "Plan a Visit", href: "/new" },
   { label: "Partnership", href: "/partnership" },
   { label: "Baptism", href: "/baptism" },
-  { label: "Life Groups", href: "/ministries/life-groups" },
-  { label: "Serve", href: "/ministries/serving" },
+  { label: "Life Groups", href: "https://180life.churchcenter.com/groups/180-life-groups", external: true },
+  { label: "Serve", href: "https://180life.churchcenter.com/people/forms/405849", external: true },
+  { label: "Message Archive", href: "https://180life.churchcenter.com/channels/12038/series", external: true },
   { label: "Stories", href: "/stories" },
   { label: "Prayer Request", href: "/contact" },
 ];
@@ -117,6 +119,7 @@ export function Footer({
                   <li key={link.label}>
                     <a
                       href={link.href}
+                      {...(link.external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
                       className="text-white/50 hover:text-amber transition-colors text-sm"
                     >
                       {link.label}
@@ -136,6 +139,7 @@ export function Footer({
                   <li key={link.label}>
                     <a
                       href={link.href}
+                      {...(link.external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
                       className="text-white/50 hover:text-amber transition-colors text-sm"
                     >
                       {link.label}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -131,6 +131,7 @@ export function Hero({ hero }: HeroProps) {
           </a>
           <a
             href={hero.ctaSecondary.link}
+            {...(hero.ctaSecondary.link.startsWith("http") ? { target: "_blank", rel: "noopener noreferrer" } : {})}
             className="px-8 py-4 text-white font-semibold rounded-full text-lg border-2 border-white/20 hover:bg-white/10 transition-all hover:-translate-y-0.5"
           >
             {hero.ctaSecondary.text}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -12,6 +12,8 @@ const navLinks = [
   { label: "Leadership", href: "/leadership" },
   { label: "Ministries", href: "/ministries" },
   { label: "Sermons", href: "/sermons" },
+  { label: "Events", href: "https://180life.churchcenter.com/registrations/events/campus/13393", external: true },
+  { label: "Watch Live", href: "https://180life.online.church/", external: true },
   { label: "Contact", href: "/contact" },
 ];
 
@@ -66,6 +68,7 @@ export function Navbar() {
             <a
               key={link.href}
               href={link.href}
+              {...(link.external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
               className={cn(
                 "text-sm font-medium tracking-wide uppercase transition-colors",
                 pathname === link.href
@@ -118,6 +121,7 @@ export function Navbar() {
                 <a
                   key={link.href}
                   href={link.href}
+                  {...(link.external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
                   onClick={() => setMobileOpen(false)}
                   className={cn(
                     "text-base font-medium py-2 transition-colors",

--- a/src/components/templates/ContentPageTemplate.tsx
+++ b/src/components/templates/ContentPageTemplate.tsx
@@ -2,15 +2,15 @@ import { Navbar } from "@/components/Navbar";
 import { Footer } from "@/components/Footer";
 import { PageHero } from "@/components/PageHero";
 import { ContentSection } from "@/components/ContentSection";
-import { getFooterProps } from "@/lib/wordpress-fallbacks";
+import { fetchFooterProps } from "@/lib/data";
 import type { ContentPageData } from "@/lib/subpage-types";
 
 interface ContentPageTemplateProps {
   data: ContentPageData;
 }
 
-export function ContentPageTemplate({ data }: ContentPageTemplateProps) {
-  const footerProps = getFooterProps();
+export async function ContentPageTemplate({ data }: ContentPageTemplateProps) {
+  const footerProps = await fetchFooterProps();
 
   return (
     <>
@@ -55,6 +55,7 @@ export function ContentPageTemplate({ data }: ContentPageTemplateProps) {
             )}
             <a
               href={data.cta.link}
+              {...(data.cta.link.startsWith("http") ? { target: "_blank", rel: "noopener noreferrer" } : {})}
               className="inline-flex items-center gap-2 px-8 py-3.5 bg-amber text-charcoal font-semibold rounded-full hover:bg-amber-light transition-all hover:shadow-lg hover:shadow-amber/25"
             >
               {data.cta.text}

--- a/src/components/templates/MinistryPageTemplate.tsx
+++ b/src/components/templates/MinistryPageTemplate.tsx
@@ -3,16 +3,16 @@ import { Footer } from "@/components/Footer";
 import { PageHero } from "@/components/PageHero";
 import { FadeIn } from "@/components/FadeIn";
 import { StaffCard } from "@/components/StaffCard";
-import { getFooterProps } from "@/lib/wordpress-fallbacks";
-import { Calendar, MapPin, Mail } from "lucide-react";
+import { fetchFooterProps } from "@/lib/data";
+import { Calendar, MapPin, Mail, ExternalLink } from "lucide-react";
 import type { MinistryPageData } from "@/lib/subpage-types";
 
 interface MinistryPageTemplateProps {
   data: MinistryPageData;
 }
 
-export function MinistryPageTemplate({ data }: MinistryPageTemplateProps) {
-  const footerProps = getFooterProps();
+export async function MinistryPageTemplate({ data }: MinistryPageTemplateProps) {
+  const footerProps = await fetchFooterProps();
 
   return (
     <>
@@ -67,6 +67,52 @@ export function MinistryPageTemplate({ data }: MinistryPageTemplateProps) {
                       )}
                     </div>
                   </div>
+                </FadeIn>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* External Links / Resources */}
+      {data.externalLinks && data.externalLinks.length > 0 && (
+        <section className="bg-soft-white py-16 sm:py-20">
+          <div className="max-w-3xl mx-auto px-6">
+            <FadeIn>
+              <h2
+                className="text-3xl font-bold text-charcoal mb-8"
+                style={{ fontFamily: "var(--font-playfair)" }}
+              >
+                Get <span className="text-amber">Connected</span>
+              </h2>
+            </FadeIn>
+            <div className="space-y-4">
+              {data.externalLinks.map((link, i) => (
+                <FadeIn key={link.href} delay={i * 0.05}>
+                  <a
+                    href={link.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="group flex items-center gap-4 p-5 rounded-xl bg-white border border-charcoal/5 hover:border-amber/30 hover:shadow-md transition-all"
+                  >
+                    <div className="w-10 h-10 rounded-lg bg-amber/10 flex items-center justify-center shrink-0 group-hover:bg-amber/20 transition-colors">
+                      <ExternalLink className="text-amber" size={18} />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <p className="font-semibold text-charcoal group-hover:text-amber transition-colors">
+                        {link.label}
+                      </p>
+                      {link.description && (
+                        <p className="text-charcoal/50 text-sm mt-0.5">
+                          {link.description}
+                        </p>
+                      )}
+                    </div>
+                    <ExternalLink
+                      size={16}
+                      className="text-charcoal/30 group-hover:text-amber shrink-0 transition-colors"
+                    />
+                  </a>
                 </FadeIn>
               ))}
             </div>

--- a/src/components/templates/SermonSeriesTemplate.tsx
+++ b/src/components/templates/SermonSeriesTemplate.tsx
@@ -3,7 +3,7 @@ import { Navbar } from "@/components/Navbar";
 import { Footer } from "@/components/Footer";
 import { PageHero } from "@/components/PageHero";
 import { FadeIn } from "@/components/FadeIn";
-import { getFooterProps } from "@/lib/wordpress-fallbacks";
+import { fetchFooterProps } from "@/lib/data";
 import { Play } from "lucide-react";
 import type { SermonSeriesData } from "@/lib/subpage-types";
 
@@ -11,8 +11,8 @@ interface SermonSeriesTemplateProps {
   data: SermonSeriesData;
 }
 
-export function SermonSeriesTemplate({ data }: SermonSeriesTemplateProps) {
-  const footerProps = getFooterProps();
+export async function SermonSeriesTemplate({ data }: SermonSeriesTemplateProps) {
+  const footerProps = await fetchFooterProps();
 
   return (
     <>

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,0 +1,176 @@
+// Unified data access layer.
+// Tries WordPress first, falls back to hardcoded content.
+// Every page should import from here — never directly from fallbacks.
+
+import {
+  getEvents,
+  getMinistries,
+  getServices,
+  getSiteSettings,
+  getLeadership,
+  getElders,
+  getMinistryPage,
+  getContentPage,
+  getSermonSeries,
+} from "./wordpress";
+
+import {
+  FALLBACK_EVENTS,
+  FALLBACK_MINISTRIES,
+  FALLBACK_SERVICES,
+  FALLBACK_SETTINGS,
+} from "./wordpress-fallbacks";
+
+import {
+  MINISTRY_PAGES,
+  CONTENT_PAGES,
+  LEADERSHIP_DATA,
+  ELDERS,
+  ELDERS_DESCRIPTION,
+  ELDERS_EMAIL,
+  SERMON_SERIES,
+  ALL_SERIES_SLUGS,
+} from "./subpage-fallbacks";
+
+import type { WPEvent, WPMinistry, WPService, WPSiteSettings } from "./wordpress-types";
+import type {
+  LeadershipData,
+  MinistryPageData,
+  ContentPageData,
+  SermonSeriesData,
+} from "./subpage-types";
+
+// ---------------------------------------------------------------------------
+// Homepage data (events, ministries, services, site settings)
+// ---------------------------------------------------------------------------
+
+export async function fetchEvents(): Promise<WPEvent[]> {
+  return getEvents().catch(() => FALLBACK_EVENTS);
+}
+
+export async function fetchMinistries(): Promise<WPMinistry[]> {
+  return getMinistries().catch(() => FALLBACK_MINISTRIES);
+}
+
+export async function fetchServices(): Promise<WPService[]> {
+  return getServices().catch(() => FALLBACK_SERVICES);
+}
+
+export async function fetchSiteSettings(): Promise<WPSiteSettings> {
+  return getSiteSettings().catch(() => FALLBACK_SETTINGS);
+}
+
+// ---------------------------------------------------------------------------
+// Footer props (derived from site settings)
+// ---------------------------------------------------------------------------
+
+export async function fetchFooterProps() {
+  const settings = await fetchSiteSettings();
+  return {
+    contact: settings.contact,
+    missionStatement: settings.missionStatement,
+    churchTagline: settings.churchTagline,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Leadership
+// ---------------------------------------------------------------------------
+
+export async function fetchLeadership(): Promise<LeadershipData> {
+  return getLeadership().catch(() => LEADERSHIP_DATA);
+}
+
+export async function fetchElders(): Promise<
+  { name: string; role: string; image?: string }[]
+> {
+  return getElders().catch(() => ELDERS);
+}
+
+/** These are unlikely to come from WP, so export directly */
+export { ELDERS_DESCRIPTION, ELDERS_EMAIL };
+
+// ---------------------------------------------------------------------------
+// Ministry subpages
+// ---------------------------------------------------------------------------
+
+export async function fetchMinistryPage(
+  slug: string
+): Promise<MinistryPageData | undefined> {
+  try {
+    return await getMinistryPage(slug);
+  } catch {
+    return MINISTRY_PAGES[slug];
+  }
+}
+
+/** All ministry slugs (for static generation) */
+export function getAllMinistrySlugs(): string[] {
+  return Object.keys(MINISTRY_PAGES);
+}
+
+/** Sync accessor for ministry hub page (grouped layout uses all entries) */
+export async function fetchAllMinistryPages(): Promise<
+  Record<string, MinistryPageData>
+> {
+  // When WP is connected, fetch each page; otherwise return all fallbacks
+  try {
+    const slugs = Object.keys(MINISTRY_PAGES);
+    const results = await Promise.all(
+      slugs.map(async (slug) => {
+        const data = await getMinistryPage(slug).catch(
+          () => MINISTRY_PAGES[slug]
+        );
+        return [slug, data] as const;
+      })
+    );
+    return Object.fromEntries(results);
+  } catch {
+    return MINISTRY_PAGES;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Content pages (about, partnership, baptism, stories, new-to-faith)
+// ---------------------------------------------------------------------------
+
+export async function fetchContentPage(
+  slug: string
+): Promise<ContentPageData | undefined> {
+  try {
+    return await getContentPage(slug);
+  } catch {
+    return CONTENT_PAGES[slug];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sermon series
+// ---------------------------------------------------------------------------
+
+export async function fetchAllSermonSeries(): Promise<
+  Record<string, SermonSeriesData>
+> {
+  return getSermonSeries().catch(() => SERMON_SERIES);
+}
+
+export async function fetchSermonSeriesBySlug(
+  slug: string
+): Promise<SermonSeriesData | undefined> {
+  try {
+    const allSeries = await getSermonSeries();
+    return allSeries[slug];
+  } catch {
+    return SERMON_SERIES[slug];
+  }
+}
+
+/** All series slugs for generateStaticParams */
+export async function getAllSeriesSlugs(): Promise<string[]> {
+  try {
+    const allSeries = await getSermonSeries();
+    return Object.keys(allSeries);
+  } catch {
+    return ALL_SERIES_SLUGS;
+  }
+}

--- a/src/lib/subpage-fallbacks.ts
+++ b/src/lib/subpage-fallbacks.ts
@@ -27,6 +27,9 @@ export const MINISTRY_PAGES: Record<string, MinistryPageData> = {
       { day: "Various Days", time: "Throughout the Week", location: "Various locations around Greater Hartford" },
     ],
     contactEmail: "info@180lifechurch.org",
+    externalLinks: [
+      { label: "Find a Life Group", href: "https://180life.churchcenter.com/groups/180-life-groups", description: "Browse and join a group on Church Center" },
+    ],
   },
   students: {
     title: "Student Ministry",
@@ -76,6 +79,13 @@ export const MINISTRY_PAGES: Record<string, MinistryPageData> = {
       { day: "Sunday", time: "11:00 AM", location: "Middle School (6th through 8th Grade)" },
     ],
     contactEmail: "jennifer@180lifechurch.org",
+    externalLinks: [
+      { label: "Child Dedication Form", href: "https://180life.churchcenter.com/people/forms/298308", description: "Submit a child dedication request" },
+      { label: "Kids Video Lessons", href: "https://www.youtube.com/channel/UCFBn8FidToPCTIE2F4FK_VQ", description: "180 Kids lessons on YouTube" },
+      { label: "Preschool Curriculum", href: "https://drive.google.com/drive/folders/1Y6Ju81CK_9uxhY5a0S7SJniMQvk1ooEh", description: "Google Drive folder for preschool age group" },
+      { label: "Elementary Curriculum", href: "https://drive.google.com/drive/folders/14BrOIECeTs3oDY0kO3ne3owUjwY2KAyf", description: "Google Drive folder for elementary age group" },
+      { label: "Middle School Curriculum", href: "https://drive.google.com/drive/folders/1Z4ktw7V6XGnX1uYVzLwGtONhW2FrBS3_", description: "Google Drive folder for middle school age group" },
+    ],
   },
   mens: {
     title: "Men's Ministry",
@@ -175,6 +185,9 @@ export const MINISTRY_PAGES: Record<string, MinistryPageData> = {
       "\"God is not unjust; he will not forget your work and the love you have shown him as you have helped his people and continue to help them.\" (Hebrews 6:10, NIV)",
     ],
     contactEmail: "info@180lifechurch.org",
+    externalLinks: [
+      { label: "Apply to Serve", href: "https://180life.churchcenter.com/people/forms/405849", description: "Fill out the serving application on Church Center" },
+    ],
   },
   "marriage-prep": {
     title: "Marriage Prep",
@@ -307,8 +320,8 @@ export const CONTENT_PAGES: Record<string, ContentPageData> = {
       heading: "Interested in Baptism or Dedication?",
       description:
         "Congratulations! We would love to celebrate this step with you.",
-      text: "Get in Touch",
-      link: "/contact",
+      text: "Sign Up for Baptism",
+      link: "https://180life.churchcenter.com/registrations/events/3506531",
     },
   },
   stories: {
@@ -393,13 +406,13 @@ export const LEADERSHIP_DATA: LeadershipData = {
     {
       name: "Josh Poteet",
       role: "Lead Pastor",
-      image: "/images/staff/placeholder-male.jpg",
+      image: "https://180lifechurch.org/wp-content/uploads/2023/08/josh-1.png",
       bio: "Born in Ohio, Josh grew up in Florida. He and Jennie tied the knot in 2015 and they now have two kids, Lilla and Ezra. Prior to ministry, Josh worked in the Army National Guard Infantry and as an EMT. Since then, he completed his Masters in Theological Studies and has been serving within the local church. Josh is a deep believer in relational discipleship. He personally experienced tremendous life change through discipleship and it is now his passion to create and multiply that culture wherever he goes.",
     },
     {
       name: "Nicholas Leadbeater",
       role: "Pastor for Ministry Development",
-      image: "/images/staff/placeholder-male.jpg",
+      image: "https://180lifechurch.org/wp-content/uploads/2023/08/Nic1.png",
       bio: "While now living in New England, Nicholas is a native of old England. His family is from Birmingham in the center of the UK. After working at a University in London for five years as a Chemistry Professor, he had the opportunity to move to the University of Connecticut. Nicholas and his wife Susan live in Southington. They have been a part of the church since 2006. He was ordained in 2019 and often gets to put his teaching hat on, giving some Sunday morning messages.",
     },
   ],
@@ -407,43 +420,43 @@ export const LEADERSHIP_DATA: LeadershipData = {
     {
       name: "Chip Anthony",
       role: "Operations and Student Ministry Director",
-      image: "/images/staff/placeholder-male.jpg",
+      image: "https://180lifechurch.org/wp-content/uploads/2023/08/chip1.png",
       bio: "Born and raised in Connecticut, Chip attended college right down the road from the church in West Hartford. He found the church in January 2006 and felt that it was a place he could truly feel God moving. He joined staff in June 2009. Some of his duties include operations, partnership, life groups, students, and special events. Chip is married to Amanda and they reside in Farmington, CT with their two sons Christian and Thomas.",
     },
     {
       name: "Jennifer Byrne",
       role: "Children's Ministry Director",
-      image: "/images/staff/placeholder-female.jpg",
+      image: "https://180lifechurch.org/wp-content/uploads/2023/08/Jen1.png",
       bio: "Jen joined the team as the Children's Ministry Director in May 2022 but has been attending 180 Life Church since 2008. Originally from a small farm town in Illinois, Jen is passionate about serving the local community, hosting kids and families, and supporting moms and families in this parenting journey. She lives in West Hartford with her husband Jeremy and three daughters Johanna, Julianne, and Jade.",
     },
     {
       name: "Ben Valentine",
       role: "Director of Worship & Young Adults",
-      image: "/images/staff/placeholder-male.jpg",
+      image: "https://180lifechurch.org/wp-content/uploads/2024/05/Untitled-design80.png",
       bio: "Born and raised in the Natural State, Ben recently moved to Connecticut with his wife Grace. He has a passion for leading Christ-centered worship that ushers people into the presence of God, and to see Young Adults emboldened and equipped to be the hands and feet of Jesus making and sending disciples.",
     },
     {
       name: "Emily Oaks",
       role: "Women's Ministry Director",
-      image: "/images/staff/placeholder-female.jpg",
+      image: "https://180lifechurch.org/wp-content/uploads/2026/02/DSCF3528-2.jpg",
       bio: "Emily grew up in Connecticut and is grateful to now call West Hartford home. She first began attending 180 Life Church in 2017. In the fall of 2025, she stepped into the role of Women's Ministry Director. She is passionate about serving the Lord, growing in her own faith, and walking in relationships with others. Outside of church, she is an elementary school teacher in West Hartford.",
     },
     {
       name: "Jim Richert",
       role: "Men's Ministry Director",
-      image: "/images/staff/placeholder-male.jpg",
+      image: "https://180lifechurch.org/wp-content/uploads/2026/03/Life1803of15-2.jpg",
       bio: "Jim is an elder and a lifelong follower of Christ who has been attending 180 Life Church since 2012. Originally from upstate New York, Jim has been married to his best friend Tanya since 2000 and is a dad to three amazing adult children (Caleb, Faith, and Noah). Jim's work focuses on the unique needs of making and sending men as disciples and exhorting them to step up in all areas of their life.",
     },
     {
       name: "Tinisha Noah",
       role: "Middle School Curriculum Coordinator",
-      image: "/images/staff/placeholder-female.jpg",
+      image: "https://180lifechurch.org/wp-content/uploads/2026/02/DSCF3625-2.jpg",
       bio: "Born and raised in Newfoundland, Canada, Tinisha moved to Connecticut in 2017. She resides in Windsor, CT and is married to her husband Blessing Noah. They have three young kids: Grace, Seth, and Trinity. Tinisha joined the Kids Ministry Team in March 2024. She has a passion for Kids and Youth Ministry and a desire to see the next generation know and love God.",
     },
     {
       name: "Ashley Perri",
       role: "Kids Curriculum Specialist",
-      image: "/images/staff/placeholder-female.jpg",
+      image: "https://180lifechurch.org/wp-content/uploads/2022/06/360_F_622414122_8SjZepAxG7hRr66C7APlMQPkCUJVH5tu.jpg",
       bio: "Ashley is our Kids Curriculum Specialist for ages birth through 5th grade. She received her bachelor's degree in middle school math and science education from Valparaiso University in 2009. She and her husband Ryan are both originally from the Chicago area but have called Farmington home since 2020. They have 3 boys: Jackson, Wyatt, and Miles.",
     },
   ],
@@ -454,10 +467,10 @@ export const LEADERSHIP_DATA: LeadershipData = {
 // ---------------------------------------------------------------------------
 
 export const ELDERS = [
-  { name: "Jeff Doot", role: "Secretary" },
-  { name: "Sam Kim", role: "Elder" },
-  { name: "Jim Richert", role: "Chair" },
-  { name: "Jose Rios", role: "Treasurer" },
+  { name: "Jeff Doot", role: "Secretary", image: "https://180lifechurch.org/wp-content/uploads/2023/12/Life18014of15.jpg" },
+  { name: "Sam Kim", role: "Elder", image: "https://180lifechurch.org/wp-content/uploads/2023/12/Life18015of15.jpg" },
+  { name: "Jim Richert", role: "Chair", image: "https://180lifechurch.org/wp-content/uploads/2023/12/Life1803of15.jpg" },
+  { name: "Jose Rios", role: "Treasurer", image: "https://180lifechurch.org/wp-content/uploads/2025/06/Screenshot-2025-06-11-at-9.47.26%E2%80%AFPM-e1749693037632.png" },
 ];
 
 export const ELDERS_DESCRIPTION =

--- a/src/lib/subpage-types.ts
+++ b/src/lib/subpage-types.ts
@@ -8,6 +8,8 @@ export interface MinistryPageData {
   schedule?: { day: string; time: string; location?: string }[];
   leaders?: { name: string; role: string; image: string }[];
   contactEmail?: string;
+  /** External links (Church Center, Google Drive, YouTube, etc.) */
+  externalLinks?: { label: string; href: string; description?: string }[];
 }
 
 export interface ContentPageData {

--- a/src/lib/wordpress-fallbacks.ts
+++ b/src/lib/wordpress-fallbacks.ts
@@ -153,8 +153,8 @@ export const FALLBACK_SETTINGS: WPSiteSettings = {
     description:
       "We exist to make and send disciples who love and live like Jesus. Come as you are. You're welcome here.",
     image: "/images/hero-worship.jpg",
-    ctaPrimary: { text: "Plan Your Visit", link: "#visit" },
-    ctaSecondary: { text: "Watch Online", link: "#watch" },
+    ctaPrimary: { text: "Plan Your Visit", link: "/new" },
+    ctaSecondary: { text: "Watch Online", link: "https://180life.online.church/" },
   },
   about: {
     label: "Gather, Grow & Go",
@@ -180,6 +180,7 @@ export const FALLBACK_SETTINGS: WPSiteSettings = {
     facebook: "https://www.facebook.com/180LifeChurch",
     instagram: "https://www.instagram.com/180lifechurch/",
     youtube: "https://www.youtube.com/@180lifechurch",
+    vimeo: "https://vimeo.com/180lifechurch",
   },
   cta: {
     label: "Take Your Next Step",

--- a/src/lib/wordpress-types.ts
+++ b/src/lib/wordpress-types.ts
@@ -63,6 +63,7 @@ export interface WPSocialData {
   facebook: string;
   instagram: string;
   youtube: string;
+  vimeo?: string;
 }
 
 export interface WPCTAData {

--- a/src/lib/wordpress.ts
+++ b/src/lib/wordpress.ts
@@ -248,6 +248,9 @@ function parseSocialData(acf: Record<string, unknown>): WPSocialData {
     youtube:
       (acf.social_youtube as string) ||
       "https://www.youtube.com/@180lifechurch",
+    vimeo:
+      (acf.social_vimeo as string) ||
+      "https://vimeo.com/180lifechurch",
   };
 }
 
@@ -264,6 +267,197 @@ function parseCTAData(acf: Record<string, unknown>): WPCTAData {
     secondaryText: (acf.cta_secondary_text as string) || "Contact Us",
     secondaryLink: (acf.cta_secondary_link as string) || "/contact",
   };
+}
+
+// ---------------------------------------------------------------------------
+// Leadership
+// ---------------------------------------------------------------------------
+
+import type {
+  LeadershipData,
+  StaffMember,
+  MinistryPageData,
+  ContentPageData,
+  SermonSeriesData,
+} from "./subpage-types";
+
+export async function getLeadership(): Promise<LeadershipData> {
+  const posts = await wpFetch<WPPostRaw[]>(
+    "staff?per_page=50&_fields=id,title,acf"
+  );
+
+  const staff: StaffMember[] = posts.map((post) => ({
+    name: post.title.rendered,
+    role: (post.acf.staff_role as string) || "",
+    image: extractImageUrl(post.acf.staff_photo) || "/images/staff/placeholder-male.jpg",
+    bio: (post.acf.staff_bio as string) || undefined,
+  }));
+
+  // Split into pastors (role contains "Pastor") and staff
+  const pastors = staff.filter((s) =>
+    s.role.toLowerCase().includes("pastor")
+  );
+  const team = staff.filter(
+    (s) => !s.role.toLowerCase().includes("pastor")
+  );
+
+  return { pastors, staff: team };
+}
+
+export async function getElders(): Promise<
+  { name: string; role: string; image?: string }[]
+> {
+  const posts = await wpFetch<WPPostRaw[]>(
+    "elder?per_page=20&_fields=id,title,acf"
+  );
+
+  return posts.map((post) => ({
+    name: post.title.rendered,
+    role: (post.acf.elder_role as string) || "Elder",
+    image: extractImageUrl(post.acf.elder_photo) || undefined,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Ministry Pages (individual subpage content)
+// ---------------------------------------------------------------------------
+
+export async function getMinistryPage(
+  slug: string
+): Promise<MinistryPageData> {
+  const posts = await wpFetch<WPPostRaw[]>(
+    `ministry-page?slug=${slug}&per_page=1&_fields=id,title,acf`
+  );
+
+  if (!posts.length) throw new Error(`Ministry page not found: ${slug}`);
+  const post = posts[0];
+  const acf = post.acf;
+
+  // Parse description: ACF WYSIWYG or repeater
+  const descRaw = acf.ministry_description as string | string[];
+  const description = Array.isArray(descRaw)
+    ? descRaw
+    : (descRaw || "")
+        .split(/<\/?p>/)
+        .map((s: string) => s.trim())
+        .filter(Boolean);
+
+  // Parse schedule: ACF repeater
+  const schedRaw = acf.ministry_schedule as
+    | { day: string; time: string; location?: string }[]
+    | undefined;
+
+  // Parse external links: ACF repeater
+  const linksRaw = acf.ministry_external_links as
+    | { label: string; href: string; description?: string }[]
+    | undefined;
+
+  return {
+    title: post.title.rendered,
+    subtitle: (acf.ministry_subtitle as string) || "",
+    slug,
+    description,
+    schedule: schedRaw || undefined,
+    contactEmail: (acf.ministry_contact_email as string) || undefined,
+    externalLinks: linksRaw || undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Content Pages (about, partnership, baptism, stories, new-to-faith)
+// ---------------------------------------------------------------------------
+
+export async function getContentPage(
+  slug: string
+): Promise<ContentPageData> {
+  const posts = await wpFetch<WPPostRaw[]>(
+    `content-page?slug=${slug}&per_page=1&_fields=id,title,acf`
+  );
+
+  if (!posts.length) throw new Error(`Content page not found: ${slug}`);
+  const post = posts[0];
+  const acf = post.acf;
+
+  // Parse sections: ACF flexible content or repeater
+  const sectionsRaw = acf.page_sections as
+    | {
+        label?: string;
+        heading: string;
+        heading_accent?: string;
+        body: string;
+        image_src?: string;
+        image_alt?: string;
+        image_position?: "left" | "right";
+      }[]
+    | undefined;
+
+  const sections = (sectionsRaw || []).map((s) => ({
+    label: s.label,
+    heading: s.heading,
+    headingAccent: s.heading_accent,
+    body: s.body
+      .split(/<\/?p>/)
+      .map((t: string) => t.trim())
+      .filter(Boolean),
+    image: s.image_src
+      ? { src: s.image_src, alt: s.image_alt || "", position: s.image_position }
+      : undefined,
+  }));
+
+  // Parse CTA
+  const ctaRaw = acf.page_cta as
+    | { heading: string; description?: string; text: string; link: string }
+    | undefined;
+
+  return {
+    title: post.title.rendered,
+    subtitle: (acf.page_subtitle as string) || undefined,
+    breadcrumbs: [{ label: post.title.rendered, href: `/${slug}` }],
+    sections,
+    cta: ctaRaw || undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sermon Series
+// ---------------------------------------------------------------------------
+
+export async function getSermonSeries(): Promise<
+  Record<string, SermonSeriesData>
+> {
+  const posts = await wpFetch<WPPostRaw[]>(
+    "sermon-series?per_page=50&_fields=id,title,acf"
+  );
+
+  const result: Record<string, SermonSeriesData> = {};
+
+  for (const post of posts) {
+    const acf = post.acf;
+    const slug = (acf.series_slug as string) || post.title.rendered.toLowerCase().replace(/\s+/g, "-");
+
+    const sermonsRaw = acf.series_sermons as
+      | { title: string; date: string; youtube_id: string; speaker?: string }[]
+      | undefined;
+
+    result[slug] = {
+      title: post.title.rendered,
+      subtitle: (acf.series_subtitle as string) || "",
+      slug,
+      description: ((acf.series_description as string) || "")
+        .split(/<\/?p>/)
+        .map((s: string) => s.trim())
+        .filter(Boolean),
+      image: extractImageUrl(acf.series_image) || "/images/series/placeholder.jpg",
+      sermons: (sermonsRaw || []).map((s) => ({
+        title: s.title,
+        date: s.date,
+        youtubeId: s.youtube_id,
+        speaker: s.speaker,
+      })),
+    };
+  }
+
+  return result;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **External service links wired** across the entire site to match the live 180lifechurch.org integrations (Church Center, livestream, WordPress images)
- **Unified data access layer** (`src/lib/data.ts`) so every page tries WordPress first and falls back to hardcoded content, making the site ready for headless CMS without code changes
- **Leadership photos from WordPress** -- all 9 staff + 4 elder headshots pulled from `wp-content/uploads`
- **WordPress setup documentation** for developers (ACF fields, CPTs, webhooks, Vercel config)
- **Editorial guide** for non-technical church staff (plain English, step-by-step, FAQ)

## External Links Added

| Service | Where | URL |
|---------|-------|-----|
| Church Center Giving | Give page, corrected subdomain | `180life.churchcenter.com/giving` |
| Church Center Events | Navbar, Footer | `180life.churchcenter.com/registrations/events/campus/13393` |
| Church Center Life Groups | Footer, Life Groups ministry page | `180life.churchcenter.com/groups/180-life-groups` |
| Church Center Serving | Footer, Serving + Care ministry pages | `180life.churchcenter.com/people/forms/405849` |
| Church Center Baptism | Baptism CTA button | `180life.churchcenter.com/registrations/events/3506531` |
| Church Center Messages | Footer, Sermons page | `180life.churchcenter.com/channels/12038/series` |
| Child Dedication Form | Kids ministry page | `180life.churchcenter.com/people/forms/298308` |
| Livestream | Navbar, Footer, Hero CTA | `180life.online.church` |
| FPU | Give page | `ramseysolutions.com/ramseyplus/financial-peace` |
| Kids YouTube | Kids ministry page | YouTube channel link |
| Kids Curriculum | Kids ministry page | 3 Google Drive folder links |
| Vimeo | Social data | `vimeo.com/180lifechurch` |
| WP Staff Photos | Leadership page | 9 staff + 4 elder photos from `wp-content/uploads` |

## Architecture: Data Access Layer

**Before:** Homepage used `wordpress.ts` fetch with fallbacks; all 40 subpages imported directly from `subpage-fallbacks.ts` (would ignore WordPress data when connected).

**After:** All pages import from `src/lib/data.ts`, which wraps every fetch with `getX().catch(() => FALLBACK_X)`.

```
src/lib/data.ts          <-- every page imports from here
  -> src/lib/wordpress.ts    <-- tries WP REST API + ACF
  -> src/lib/subpage-fallbacks.ts  <-- fallback if WP unavailable
  -> src/lib/wordpress-fallbacks.ts
```

New WP fetch functions added: `getLeadership()`, `getElders()`, `getMinistryPage(slug)`, `getContentPage(slug)`, `getSermonSeries()`

## Documentation

- `docs/wordpress-setup-guide.md` -- Developer guide: architecture, env vars, 9 CPTs, 12 ACF field groups, webhook config, Vercel settings, testing checklist, troubleshooting
- `docs/wordpress-editorial-guide.md` -- Staff guide: plain English, step-by-step for every common task, image recommendations, YouTube ID finder, FAQ

## Files Changed

- 42 files changed, 1708 insertions, 222 deletions
- 27 page routes updated to async + data layer
- 3 templates converted to async server components
- 4 shared components updated (Navbar, Footer, Hero, Events)
- 5 data/type files modified or created

## Test plan

- [x] `npm run build` passes with 41 routes, zero errors
- [x] All Church Center links open correct pages in new tabs
- [x] Livestream link opens `180life.online.church` in new tab
- [x] Leadership page loads staff photos from WordPress
- [x] Elder photos render on leadership page
- [x] Kids ministry page shows external links section (Child Dedication, YouTube, Google Drive)
- [x] Serving ministry page shows "Apply to Serve" external link
- [x] Life Groups ministry page shows "Find a Life Group" external link
- [x] Hero "Plan Your Visit" links to /new; "Watch Online" opens livestream
- [x] Baptism CTA links to Church Center registration
- [x] Give page corrected to `180life.churchcenter.com` (not `180lifechurch`)
- [x] Site renders identically to current state (fallbacks active, no WP configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)